### PR TITLE
93/add derived_task_id argument

### DIFF
--- a/R/config_tasks-utils.R
+++ b/R/config_tasks-utils.R
@@ -1,0 +1,29 @@
+get_round_config <- function(config_tasks, round_id) {
+  round_idx <- hubUtils::get_round_idx(config_tasks, round_id)
+  purrr::pluck(
+    config_tasks,
+    "rounds",
+    round_idx
+  )
+}
+
+get_round_output_types <- function(config_tasks, round_id) {
+  round_config <- get_round_config(config_tasks, round_id)
+  purrr::map(
+    round_config[["model_tasks"]],
+    ~ .x[["output_type"]]
+  )
+}
+
+get_round_output_type_names <- function(config_tasks, round_id,
+                                        collapse = TRUE) {
+  out <- get_round_output_types(config_tasks, round_id) %>%
+    purrr::map(names)
+
+  if (collapse) {
+    purrr::flatten_chr(out) %>%
+      unique()
+  } else {
+    out
+  }
+}

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -478,37 +478,6 @@ extract_mt_output_type_ids <- function(x, config_tid) {
   )
 }
 
-
-get_round_config <- function(config_tasks, round_id) {
-  round_idx <- hubUtils::get_round_idx(config_tasks, round_id)
-  purrr::pluck(
-    config_tasks,
-    "rounds",
-    round_idx
-  )
-}
-
-get_round_output_types <- function(config_tasks, round_id) {
-  round_config <- get_round_config(config_tasks, round_id)
-  purrr::map(
-    round_config[["model_tasks"]],
-    ~ .x[["output_type"]]
-  )
-}
-
-get_round_output_type_names <- function(config_tasks, round_id,
-                                        collapse = TRUE) {
-  out <- get_round_output_types(config_tasks, round_id) %>%
-    purrr::map(names)
-
-    if (collapse) {
-      purrr::flatten_chr(out) %>%
-        unique()
-    } else {
-      out
-    }
-}
-
 validate_output_types <- function(output_types, config_tasks, round_id,
                                   call = rlang::caller_call()) {
   checkmate::assert_character(output_types, null.ok = TRUE)

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -578,7 +578,7 @@ validate_derived_task_ids <- function(derived_task_ids, config_tasks, round_id) 
       c(
         "x" = "Derived task IDs cannot have required task ID values.",
         "!" = "{.val {names(has_required)[has_required]}} ha{?s/ve}
-          required task ID values."
+          required task ID values. Ignored."
       ),
       call = rlang::caller_call()
     )

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -551,6 +551,7 @@ validate_output_types <- function(output_types, config_tasks, round_id,
 validate_derived_task_ids <- function(derived_task_ids, config_tasks, round_id) {
   checkmate::assert_character(derived_task_ids, null.ok = TRUE)
   if (is.null(derived_task_ids)) {
+    return(NULL)
   }
   round_task_ids <- hubUtils::get_round_task_id_names(config_tasks, round_id)
   valid_task_ids <- intersect(derived_task_ids, round_task_ids)

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -380,7 +380,7 @@ null_taskids_to_na <- function(model_task) {
 
 # Set derived task_ids to all NULL values.
 derived_taskids_to_na <- function(model_task, derived_task_ids) {
-  if (!is.null(derived_task_ids) || length(derived_task_ids) > 0L) {
+  if (!is.null(derived_task_ids)) {
     purrr::modify_at(
       model_task,
       .at = derived_task_ids,

--- a/man/expand_model_out_grid.Rd
+++ b/man/expand_model_out_grid.Rd
@@ -15,7 +15,8 @@ expand_model_out_grid(
   bind_model_tasks = TRUE,
   include_sample_ids = FALSE,
   compound_taskid_set = NULL,
-  output_types = NULL
+  output_types = NULL,
+  derived_task_ids = NULL
 )
 }
 \arguments{
@@ -62,8 +63,12 @@ in the round. Can be used to override the compound task ID set defined in the
 config. If \code{NULL} is provided for a given modeling task, a compound task ID set of
 all task IDs is used.}
 
-\item{output_types}{character vector of output type names to include.
+\item{output_types}{Character vector of output type names to include.
 Use to subset for grids for specific output types.}
+
+\item{derived_task_ids}{Character vector of derived task ID names (task IDs whose
+values depend on other task IDs) to ignore. Columns for such task ids will
+contain \code{NA}s.}
 }
 \value{
 If \code{bind_model_tasks = TRUE} (default) a tibble or arrow table
@@ -135,9 +140,9 @@ expand_model_out_grid(config_tasks,
   include_sample_ids = TRUE
 )
 # Hub with sample output type and compound task ID structure
-config_tasks <- hubUtils::read_config_file(system.file("config", "tasks-comp-tid.json",
-  package = "hubValidations"
-))
+config_tasks <- hubUtils::read_config_file(
+  system.file("config", "tasks-comp-tid.json", package = "hubValidations")
+)
 expand_model_out_grid(config_tasks,
   round_id = "2022-12-26",
   include_sample_ids = TRUE
@@ -160,5 +165,29 @@ expand_model_out_grid(config_tasks,
     NULL,
     NULL
   )
+)
+# Subset output types
+config_tasks <- hubUtils::read_config(
+  system.file("testhubs", "samples", package = "hubValidations")
+)
+expand_model_out_grid(config_tasks,
+  round_id = "2022-10-29",
+  include_sample_ids = TRUE,
+  bind_model_tasks = FALSE,
+  output_types = c("sample", "pmf"),
+)
+expand_model_out_grid(config_tasks,
+  round_id = "2022-10-29",
+  include_sample_ids = TRUE,
+  bind_model_tasks = TRUE,
+  output_types = "sample",
+)
+# Ignore derived task IDs
+expand_model_out_grid(config_tasks,
+  round_id = "2022-10-29",
+  include_sample_ids = TRUE,
+  bind_model_tasks = FALSE,
+  output_types = "sample",
+  derived_task_ids = "target_end_date"
 )
 }

--- a/tests/testthat/_snaps/expand_model_out_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_grid.md
@@ -635,7 +635,7 @@
     Condition
       Error in `expand_model_out_grid()`:
       x Derived task IDs cannot have required task ID values.
-      ! "location" and "variant" have required task ID values.
+      ! "location" and "variant" have required task ID values. Ignored.
 
 # expand_model_out_grid errors correctly
 

--- a/tests/testthat/_snaps/expand_model_out_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_grid.md
@@ -585,12 +585,64 @@
       x "random" is not valid output type.
       i `output_types` must be members of: "sample", "mean", and "pmf"
 
+# expand_model_out_grid derived_task_ids ignoring works
+
+    Code
+      expand_model_out_grid(config_tasks, round_id = "2022-10-22",
+        include_sample_ids = FALSE, bind_model_tasks = TRUE, output_types = "sample",
+        derived_task_ids = "target_end_date")
+    Output
+      # A tibble: 80 x 8
+         reference_date target    horizon location variant target_end_date output_type
+         <date>         <chr>       <int> <chr>    <chr>   <date>          <chr>      
+       1 2022-10-22     wk inc f~       0 US       AA      NA              sample     
+       2 2022-10-22     wk inc f~       1 US       AA      NA              sample     
+       3 2022-10-22     wk inc f~       2 US       AA      NA              sample     
+       4 2022-10-22     wk inc f~       3 US       AA      NA              sample     
+       5 2022-10-22     wk inc f~       0 01       AA      NA              sample     
+       6 2022-10-22     wk inc f~       1 01       AA      NA              sample     
+       7 2022-10-22     wk inc f~       2 01       AA      NA              sample     
+       8 2022-10-22     wk inc f~       3 01       AA      NA              sample     
+       9 2022-10-22     wk inc f~       0 02       AA      NA              sample     
+      10 2022-10-22     wk inc f~       1 02       AA      NA              sample     
+      # i 70 more rows
+      # i 1 more variable: output_type_id <chr>
+
+---
+
+    Code
+      expand_model_out_grid(config_tasks, round_id = "2022-10-22",
+        include_sample_ids = TRUE, bind_model_tasks = TRUE, output_types = "sample",
+        derived_task_ids = "target_end_date", required_vals_only = TRUE)
+    Condition
+      Warning:
+      The compound task IDs horizon and target_end_date have all optional values. Representation of compound sample modeling tasks is not fully specified.
+    Output
+      # A tibble: 4 x 5
+        reference_date location variant output_type output_type_id
+        <date>         <chr>    <chr>   <chr>       <chr>         
+      1 2022-10-22     US       AA      sample      1             
+      2 2022-10-22     01       AA      sample      2             
+      3 2022-10-22     US       BB      sample      3             
+      4 2022-10-22     01       BB      sample      4             
+
+---
+
+    Code
+      expand_model_out_grid(config_tasks, round_id = "2022-10-22",
+        include_sample_ids = FALSE, bind_model_tasks = FALSE, output_types = "sample",
+        derived_task_ids = c("location", "variant"))
+    Condition
+      Error in `expand_model_out_grid()`:
+      x Derived task IDs cannot have required task ID values.
+      ! "location" and "variant" have required task ID values.
+
 # expand_model_out_grid errors correctly
 
     Code
       expand_model_out_grid(config_tasks, round_id = "random_round_id")
     Condition
-      Error in `hubUtils::get_round_idx()`:
+      Error in `get_round_idx()`:
       ! `round_id` must be one of "2022-10-01", "2022-10-08", "2022-10-15", "2022-10-22", or "2022-10-29", not "random_round_id".
 
 ---

--- a/tests/testthat/_snaps/expand_model_out_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_grid.md
@@ -642,7 +642,7 @@
     Code
       expand_model_out_grid(config_tasks, round_id = "random_round_id")
     Condition
-      Error in `get_round_idx()`:
+      Error in `hubUtils::get_round_idx()`:
       ! `round_id` must be one of "2022-10-01", "2022-10-08", "2022-10-15", "2022-10-22", or "2022-10-29", not "random_round_id".
 
 ---

--- a/tests/testthat/_snaps/submission_tmpl.md
+++ b/tests/testthat/_snaps/submission_tmpl.md
@@ -253,7 +253,7 @@
     Code
       submission_tmpl(hub_con, round_id = "random_round_id")
     Condition
-      Error in `hubUtils::get_round_idx()`:
+      Error in `get_round_idx()`:
       ! `round_id` must be one of "2022-10-01", "2022-10-08", "2022-10-15", "2022-10-22", or "2022-10-29", not "random_round_id".
 
 ---

--- a/tests/testthat/_snaps/submission_tmpl.md
+++ b/tests/testthat/_snaps/submission_tmpl.md
@@ -253,7 +253,7 @@
     Code
       submission_tmpl(hub_con, round_id = "random_round_id")
     Condition
-      Error in `get_round_idx()`:
+      Error in `hubUtils::get_round_idx()`:
       ! `round_id` must be one of "2022-10-01", "2022-10-08", "2022-10-15", "2022-10-22", or "2022-10-29", not "random_round_id".
 
 ---

--- a/tests/testthat/test-expand_model_out_grid.R
+++ b/tests/testthat/test-expand_model_out_grid.R
@@ -395,6 +395,43 @@ test_that("expand_model_out_grid output type subsetting works", {
 
 })
 
+test_that("expand_model_out_grid derived_task_ids ignoring works", {
+  config_tasks <- hubUtils::read_config(test_path("testdata", "hub-spl"))
+
+  expect_snapshot(
+    expand_model_out_grid(config_tasks,
+                          round_id = "2022-10-22",
+                          include_sample_ids = FALSE,
+                          bind_model_tasks = TRUE,
+                          output_types = "sample",
+                          derived_task_ids = "target_end_date"
+    )
+  )
+  expect_snapshot(
+    expand_model_out_grid(config_tasks,
+                          round_id = "2022-10-22",
+                          include_sample_ids = TRUE,
+                          bind_model_tasks = TRUE,
+                          output_types = "sample",
+                          derived_task_ids = "target_end_date",
+                          required_vals_only = TRUE
+    )
+  )
+
+  expect_snapshot(
+    expand_model_out_grid(config_tasks,
+                          round_id = "2022-10-22",
+                          include_sample_ids = FALSE,
+                          bind_model_tasks = FALSE,
+                          output_types = "sample",
+                          derived_task_ids = c("location", "variant")
+    ),
+    error = TRUE
+  )
+})
+
+
+
 test_that("expand_model_out_grid errors correctly", {
   # Specifying a round in a hub with multiple rounds
   hub_con <- hubData::connect_hub(


### PR DESCRIPTION
This is the second PR associated with improving the performance of validation workflows ( #93 ) and provides a mechanism for ignoring derived task ids which can not only pollute expanded grids of valid values with effectively non valid value combinations but also significantly increase the size of expanded grids unnecessarily and affect validation performance.

To allow us to by pass such task ids this, I'm introducing a `derived_taks_ids` argument in `expand_model_out_grid()` which ignores any task id names provided when expanding the valid value grid, returning such columns as `NA`.

I've also moved some utility functions to a separate R script (`R/config_tasks-utils.R`) but nothing in these fns has actually changed