### PR TITLE
Bump minimum arrow version to CRAN 17.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person(
         given = "Anna", 
@@ -30,7 +30,7 @@ Description: This package aims at providing a simple interface to run
   continuous integration workflow.
 License: MIT + file LICENSE
 Imports: 
-    arrow (>= 12.0.0),
+    arrow (>= 17.0.0),
     checkmate,
     cli,
     config,
@@ -64,8 +64,7 @@ Remotes:
     hubverse-org/hubUtils,
     hubverse-org/hubData,
     hubverse-org/hubAdmin,
-    assignUser/octolog,
-    apache/arrow/r@apache-arrow-15.0.2
+    assignUser/octolog
 Config/testthat/edition: 3
 Config/Needs/website: pkgdown, hubverse-org/hubStyle
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# hubValidations 0.5.1
+
+* Remove dependency on development version of `arrow` package and bump required version to 17.0.0.
+
+
 # hubValidations 0.5.0
 
 This release introduces **significant improvements in the performance of submission validation** via the following changes:


### PR DESCRIPTION
This PR removes the arrow development version requirement and bumps the minimum required to CRAN version 17.0.0.