### PR TITLE
Fix bug where multi-class cols were causing exec error. Resolves #118

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubValidations 0.6.2
+
+* Fixed bug in `check_tbl_col_types()` where columns in model output data with more than one class were causing an EXEC error (#118). Thanks for the bug report @ruarai!
+
 # hubValidations 0.6.1
 
 * Changed file name header colour in `hub_validations` object `print()` method to make more visible on lighter backgrounds.

--- a/R/check_tbl_col_types.R
+++ b/R/check_tbl_col_types.R
@@ -29,7 +29,7 @@ check_tbl_col_types <- function(tbl, file_path, hub_path,
   tbl_types <- purrr::map_chr(tbl, ~ if (inherits(.x, "numeric")) {
     typeof(.x)
   } else {
-    class(.x)
+    paste(class(.x), collapse = "/")
   })
   compare_types <- schema == tbl_types
 

--- a/tests/testthat/_snaps/check_tbl_col_types.md
+++ b/tests/testthat/_snaps/check_tbl_col_types.md
@@ -25,3 +25,12 @@
       Message:
       Column data types match hub schema.
 
+# check_tbl_col_types on datetimes doesn't cause exec error
+
+    Code
+      check_tbl_col_types(tbl, file_path, hub_path)
+    Output
+      <error/check_failure>
+      Error:
+      ! Column data types do not match hub schema.  `origin_date` should be "Date" not "POSIXct/POSIXt".
+

--- a/tests/testthat/test-check_tbl_col_types.R
+++ b/tests/testthat/test-check_tbl_col_types.R
@@ -36,3 +36,15 @@ test_that(
     )
   }
 )
+
+test_that("check_tbl_col_types on datetimes doesn't cause exec error", {
+  hub_path <- system.file("testhubs/simple", package = "hubValidations")
+  file_path <- "team1-goodmodel/2022-10-08-team1-goodmodel.csv"
+  tbl <- read_model_out_file(file_path, hub_path)
+  tbl$origin_date <- as.POSIXct(tbl$origin_date)
+
+  # Should return a check_failure not an exec error
+  expect_snapshot(
+    check_tbl_col_types(tbl, file_path, hub_path)
+  )
+})


### PR DESCRIPTION
This PR fixes bug reported in #118 in `check_tbl_col_types()` where columns in model output data with more than one class, (e.g. datetime) were causing an EXEC error.

They are now handled by being concatenated. This works fine for the types we are currently supporting as they are all single class/type columns so won't be affected.

