### PR TITLE
skip submit window check

### DIFF
--- a/tests/testthat/_snaps/check_tbl_values_required.md
+++ b/tests/testthat/_snaps/check_tbl_values_required.md
@@ -224,7 +224,7 @@
 ---
 
     Code
-      check_for_errors(validate_submission(hub_path, file_path))
+      check_for_errors(val)
     Message
       
       -- 2024-10-02-UMass-HMLR.parquet ----

--- a/tests/testthat/_snaps/check_tbl_values_required.md
+++ b/tests/testthat/_snaps/check_tbl_values_required.md
@@ -224,7 +224,8 @@
 ---
 
     Code
-      check_for_errors(val)
+      check_for_errors(validate_submission(hub_path, file_path,
+        skip_submit_window_check = TRUE))
     Message
       
       -- 2024-10-02-UMass-HMLR.parquet ----

--- a/tests/testthat/test-check_tbl_values_required.R
+++ b/tests/testthat/test-check_tbl_values_required.R
@@ -276,9 +276,11 @@ test_that("(#123) check_tbl_values_required works with all optional output types
     c("24A", "24B")
   )
   # Ensure that req_vals check is the only one that fails
-  val <- validate_submission(hub_path, file_path, skip_submit_window_check = TRUE)
   expect_snapshot(
-    check_for_errors(val),
+    check_for_errors(validate_submission(
+      hub_path, file_path,
+      skip_submit_window_check = TRUE
+    )),
     error = TRUE
   )
 })

--- a/tests/testthat/test-check_tbl_values_required.R
+++ b/tests/testthat/test-check_tbl_values_required.R
@@ -276,8 +276,9 @@ test_that("(#123) check_tbl_values_required works with all optional output types
     c("24A", "24B")
   )
   # Ensure that req_vals check is the only one that fails
+  val <- validate_submission(hub_path, file_path, skip_submit_window_check = TRUE)
   expect_snapshot(
-    check_for_errors(validate_submission(hub_path, file_path)),
+    check_for_errors(val),
     error = TRUE
   )
 })


### PR DESCRIPTION
The test added to address #123 began to fail because the date had fallen outside of the submission window.

Since we were not testing the submission window, I cleaned up the test to not check for that and reran the snapshot.

This will fix #128 
