### PR TITLE
Downgrade missing metadata file to `<check_failure>` when validation model output files. (#138)

### DIFF
--- a/R/check_submission_metadata_file_exists.R
+++ b/R/check_submission_metadata_file_exists.R
@@ -38,6 +38,6 @@ check_submission_metadata_file_exists <- function(file_path, hub_path = ".") {
     msg_subject = "Metadata file",
     msg_attribute = msg_attribute,
     msg_verbs = c("exists", "does not exist"),
-    error = TRUE
+    error = FALSE
   )
 }

--- a/R/validate_model_file.R
+++ b/R/validate_model_file.R
@@ -91,9 +91,6 @@ validate_model_file <- function(hub_path, file_path,
       file_path = file_path
     ), file_path
   )
-  if (is_any_error(checks$metadata_exists)) {
-    return(checks)
-  }
 
   custom_checks <- execute_custom_checks(validations_cfg_path = validations_cfg_path)
   checks <- combine(checks, custom_checks)

--- a/inst/check_table.csv
+++ b/inst/check_table.csv
@@ -6,7 +6,7 @@ file_name,File name valid,TRUE,check_error,validate_model_file,check_file_name,,
 file_location,File located in correct team directory,FALSE,check_failure,validate_model_file,check_file_location,,FALSE
 round_id_valid,File round ID is valid hub round IDs,TRUE,check_error,validate_model_file,check_valid_round_id,,FALSE
 file_format,File format is accepted hub/round format,TRUE,check_error,validate_model_file,check_file_format,,FALSE
-metadata_exists,Model metadata file exists in expected location,TRUE,check_error,validate_model_file,check_submission_metadata_file_exists,,FALSE
+metadata_exists,Model metadata file exists in expected location,FALSE,check_failure,validate_model_file,check_submission_metadata_file_exists,,FALSE
 file_read,File can be read without errors,TRUE,check_error,validate_model_data,check_file_read,,FALSE
 valid_round_id_col,Round ID var from config exists in data column names. Skipped if `round_id_from_var` is FALSE in config.,FALSE,check_failure,validate_model_data,check_valid_round_id_col,,FALSE
 unique_round_id,Round ID column contains a single unique round ID. Skipped if `round_id_from_var` is FALSE in config.,TRUE,check_error,validate_model_data,check_tbl_unique_round_id,,FALSE

--- a/man/validate_model_file.Rd
+++ b/man/validate_model_file.Rd
@@ -85,8 +85,8 @@ Details of checks performed by \code{validate_model_file()}\if{html}{\out{<table
   <tr>
    <td style="text-align:left;font-weight: bold;"> metadata_exists </td>
    <td style="text-align:left;"> Model metadata file exists in expected location </td>
-   <td style="text-align:left;"> TRUE </td>
-   <td style="text-align:left;"> check_error </td>
+   <td style="text-align:left;"> FALSE </td>
+   <td style="text-align:left;"> check_failure </td>
    <td style="text-align:left;">  </td>
   </tr>
 </tbody>

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -184,8 +184,8 @@ Details of checks performed by \code{validate_submission()}\if{html}{\out{<table
   <tr>
    <td style="text-align:left;font-weight: bold;"> metadata_exists </td>
    <td style="text-align:left;"> Model metadata file exists in expected location </td>
-   <td style="text-align:left;"> TRUE </td>
-   <td style="text-align:left;"> check_error </td>
+   <td style="text-align:left;"> FALSE </td>
+   <td style="text-align:left;"> check_failure </td>
    <td style="text-align:left;">  </td>
   </tr>
   <tr>

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -148,8 +148,8 @@ Details of checks performed by \code{validate_submission()}\if{html}{\out{<table
   <tr>
    <td style="text-align:left;font-weight: bold;"> metadata_exists </td>
    <td style="text-align:left;"> Model metadata file exists in expected location </td>
-   <td style="text-align:left;"> TRUE </td>
-   <td style="text-align:left;"> check_error </td>
+   <td style="text-align:left;"> FALSE </td>
+   <td style="text-align:left;"> check_failure </td>
    <td style="text-align:left;">  </td>
   </tr>
   <tr>

--- a/tests/testthat/_snaps/check_submission_metadata_file_exists.md
+++ b/tests/testthat/_snaps/check_submission_metadata_file_exists.md
@@ -12,7 +12,7 @@
     Code
       check_submission_metadata_file_exists(hub_path = hub_path, file_path = "random-model/2022-10-01-random-model.csv")
     Output
-      <error/check_error>
+      <error/check_failure>
       Error:
       ! Metadata file does not exist at path 'model-metadata/random-model.yml' or 'model-metadata/random-model.yaml'.
 

--- a/tests/testthat/_snaps/validate_pr.md
+++ b/tests/testthat/_snaps/validate_pr.md
@@ -240,14 +240,14 @@
     Code
       str(mod_checks_error)
     Output
-      Classes 'hub_validations', 'list'  hidden list of 32
-       $ valid_config           :List of 4
+      List of 48
+       $ valid_config             :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ model_output_mod       :List of 6
+       $ model_output_mod         :List of 6
         ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -255,7 +255,7 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ model_output_mod_1     :List of 6
+       $ model_output_mod_1       :List of 6
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -263,7 +263,7 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ model_metadata_mod     :List of 6
+       $ model_metadata_mod       :List of 6
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -271,92 +271,92 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ file_exists            :List of 4
+       $ file_exists              :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name              :List of 4
+       $ file_name                :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location          :List of 4
+       $ file_location            :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid         :List of 4
+       $ round_id_valid           :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format            :List of 4
+       $ file_format              :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists        :List of 4
+       $ metadata_exists          :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read              :List of 4
+       $ file_read                :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col     :List of 4
+       $ valid_round_id_col       :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id        :List of 4
+       $ unique_round_id          :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id         :List of 4
+       $ match_round_id           :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames               :List of 4
+       $ colnames                 :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types              :List of 4
+       $ col_types                :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals             :List of 5
+       $ valid_vals               :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique            :List of 4
+       $ rows_unique              :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals               :List of 5
+       $ req_vals                 :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -369,101 +369,208 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid        :List of 4
+       $ value_col_valid          :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc     :List of 5
+       $ value_col_non_desc       :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1         :List of 4
+       $ value_col_sum1           :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_taskid_set:List of 4
+       $ spl_compound_taskid_set  :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_taskid_set"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_tid       :List of 4
+       $ spl_compound_tid         :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_non_compound_tid   :List of 4
+       $ spl_non_compound_tid     :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_non_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_n                  :List of 4
+       $ spl_n                    :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_n"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists_1          :List of 4
+       $ file_exists_1            :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name_1            :List of 4
+       $ file_name_1              :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location_1        :List of 4
+       $ file_location_1          :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid_1       :List of 4
+       $ round_id_valid_1         :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format_1          :List of 4
+       $ file_format_1            :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists_1      :List of 6
+       $ metadata_exists_1        :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
-        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
+       $ file_read_1              :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col_1     :List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id_1        :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id_1         :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames_1               :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types_1              :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals_1             :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique_1            :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals_1               :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ missing       : tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ age_group     : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid_1        :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc_1     :List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1_1         :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_taskid_set_1:List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_taskid_set"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_tid_1       :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_non_compound_tid_1   :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_non_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_n_1                  :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_n"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       - attr(*, "class")= chr [1:2] "hub_validations" "list"
 
 ---
 
     Code
       str(mod_checks_warn)
     Output
-      Classes 'hub_validations', 'list'  hidden list of 32
-       $ valid_config           :List of 4
+      List of 48
+       $ valid_config             :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ model_output_mod       :List of 6
+       $ model_output_mod         :List of 6
         ..$ message       : chr "Previously submitted model output files must not be modified. \n 'model-output/hub-baseline/2022-10-08-hub-base"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -471,7 +578,7 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
-       $ model_output_mod_1     :List of 6
+       $ model_output_mod_1       :List of 6
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -479,7 +586,7 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
-       $ model_metadata_mod     :List of 6
+       $ model_metadata_mod       :List of 6
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -487,92 +594,92 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
-       $ file_exists            :List of 4
+       $ file_exists              :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name              :List of 4
+       $ file_name                :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location          :List of 4
+       $ file_location            :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid         :List of 4
+       $ round_id_valid           :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format            :List of 4
+       $ file_format              :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists        :List of 4
+       $ metadata_exists          :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read              :List of 4
+       $ file_read                :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col     :List of 4
+       $ valid_round_id_col       :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id        :List of 4
+       $ unique_round_id          :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id         :List of 4
+       $ match_round_id           :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames               :List of 4
+       $ colnames                 :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types              :List of 4
+       $ col_types                :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals             :List of 5
+       $ valid_vals               :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique            :List of 4
+       $ rows_unique              :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals               :List of 5
+       $ req_vals                 :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -585,204 +692,311 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid        :List of 4
+       $ value_col_valid          :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc     :List of 5
+       $ value_col_non_desc       :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1         :List of 4
+       $ value_col_sum1           :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_taskid_set:List of 4
+       $ spl_compound_taskid_set  :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_taskid_set"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_tid       :List of 4
+       $ spl_compound_tid         :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_non_compound_tid   :List of 4
+       $ spl_non_compound_tid     :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_non_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_n                  :List of 4
+       $ spl_n                    :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_n"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists_1          :List of 4
+       $ file_exists_1            :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name_1            :List of 4
+       $ file_name_1              :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location_1        :List of 4
+       $ file_location_1          :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid_1       :List of 4
+       $ round_id_valid_1         :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format_1          :List of 4
+       $ file_format_1            :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists_1      :List of 6
+       $ metadata_exists_1        :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
-        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
+       $ file_read_1              :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col_1     :List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id_1        :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id_1         :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames_1               :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types_1              :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals_1             :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique_1            :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals_1               :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ missing       : tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ age_group     : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid_1        :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc_1     :List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1_1         :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_taskid_set_1:List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_taskid_set"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_tid_1       :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_non_compound_tid_1   :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_non_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_n_1                  :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_n"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       - attr(*, "class")= chr [1:2] "hub_validations" "list"
 
 ---
 
     Code
       str(mod_checks_message)
     Output
-      Classes 'hub_validations', 'list'  hidden list of 32
-       $ valid_config           :List of 4
+      List of 48
+       $ valid_config             :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ model_output_mod       :List of 4
+       $ model_output_mod         :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/hub-baseline/2022-10-08-hub-baseline.csv' modified."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ model_output_mod_1     :List of 4
+       $ model_output_mod_1       :List of 4
         ..$ message       : chr "Previously submitted model output file\n          'model-output/team1-goodmodel/2022-10-15-team1-goodmodel.csv' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ model_metadata_mod     :List of 4
+       $ model_metadata_mod       :List of 4
         ..$ message       : chr "Previously submitted model metadata file\n          'model-metadata/team1-goodmodel.yaml' removed."
         ..$ where         : 'fs_path' chr "team1-goodmodel.yaml"
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists            :List of 4
+       $ file_exists              :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name              :List of 4
+       $ file_name                :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location          :List of 4
+       $ file_location            :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid         :List of 4
+       $ round_id_valid           :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format            :List of 4
+       $ file_format              :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists        :List of 4
+       $ metadata_exists          :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read              :List of 4
+       $ file_read                :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col     :List of 4
+       $ valid_round_id_col       :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id        :List of 4
+       $ unique_round_id          :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id         :List of 4
+       $ match_round_id           :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames               :List of 4
+       $ colnames                 :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types              :List of 4
+       $ col_types                :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals             :List of 5
+       $ valid_vals               :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique            :List of 4
+       $ rows_unique              :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals               :List of 5
+       $ req_vals                 :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -795,186 +1009,293 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid        :List of 4
+       $ value_col_valid          :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc     :List of 5
+       $ value_col_non_desc       :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1         :List of 4
+       $ value_col_sum1           :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_taskid_set:List of 4
+       $ spl_compound_taskid_set  :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_taskid_set"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_tid       :List of 4
+       $ spl_compound_tid         :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_non_compound_tid   :List of 4
+       $ spl_non_compound_tid     :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_non_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_n                  :List of 4
+       $ spl_n                    :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_n"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists_1          :List of 4
+       $ file_exists_1            :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name_1            :List of 4
+       $ file_name_1              :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location_1        :List of 4
+       $ file_location_1          :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid_1       :List of 4
+       $ round_id_valid_1         :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format_1          :List of 4
+       $ file_format_1            :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists_1      :List of 6
+       $ metadata_exists_1        :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
-        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
+       $ file_read_1              :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col_1     :List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id_1        :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id_1         :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames_1               :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types_1              :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals_1             :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique_1            :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals_1               :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ missing       : tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ age_group     : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid_1        :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc_1     :List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1_1         :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_taskid_set_1:List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_taskid_set"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_tid_1       :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_non_compound_tid_1   :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_non_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_n_1                  :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_n"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       - attr(*, "class")= chr [1:2] "hub_validations" "list"
 
 ---
 
     Code
       str(mod_checks_none)
     Output
-      Classes 'hub_validations', 'list'  hidden list of 29
-       $ valid_config           :List of 4
+      List of 45
+       $ valid_config             :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_exists            :List of 4
+       $ file_exists              :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name              :List of 4
+       $ file_name                :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location          :List of 4
+       $ file_location            :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid         :List of 4
+       $ round_id_valid           :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format            :List of 4
+       $ file_format              :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists        :List of 4
+       $ metadata_exists          :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read              :List of 4
+       $ file_read                :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col     :List of 4
+       $ valid_round_id_col       :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id        :List of 4
+       $ unique_round_id          :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id         :List of 4
+       $ match_round_id           :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames               :List of 4
+       $ colnames                 :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types              :List of 4
+       $ col_types                :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals             :List of 5
+       $ valid_vals               :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique            :List of 4
+       $ rows_unique              :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals               :List of 5
+       $ req_vals                 :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -987,101 +1308,208 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid        :List of 4
+       $ value_col_valid          :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc     :List of 5
+       $ value_col_non_desc       :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1         :List of 4
+       $ value_col_sum1           :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_taskid_set:List of 4
+       $ spl_compound_taskid_set  :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_taskid_set"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_tid       :List of 4
+       $ spl_compound_tid         :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_non_compound_tid   :List of 4
+       $ spl_non_compound_tid     :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_non_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_n                  :List of 4
+       $ spl_n                    :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_n"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists_1          :List of 4
+       $ file_exists_1            :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name_1            :List of 4
+       $ file_name_1              :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location_1        :List of 4
+       $ file_location_1          :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid_1       :List of 4
+       $ round_id_valid_1         :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format_1          :List of 4
+       $ file_format_1            :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists_1      :List of 6
+       $ metadata_exists_1        :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
-        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
+       $ file_read_1              :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col_1     :List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id_1        :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id_1         :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames_1               :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types_1              :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals_1             :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique_1            :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals_1               :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ missing       : tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ age_group     : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid_1        :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc_1     :List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1_1         :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_taskid_set_1:List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_taskid_set"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_tid_1       :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_non_compound_tid_1   :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_non_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_n_1                  :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_n"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       - attr(*, "class")= chr [1:2] "hub_validations" "list"
 
 ---
 
     Code
       str(mod_checks_in_window)
     Output
-      Classes 'hub_validations', 'list'  hidden list of 31
-       $ valid_config           :List of 4
+      List of 47
+       $ valid_config             :List of 4
         ..$ message       : chr "All hub config files are valid. \n "
         ..$ where         : chr "mod_del_hub"
         ..$ call          : chr "check_config_hub_valid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ model_output_mod       :List of 6
+       $ model_output_mod         :List of 6
         ..$ message       : chr "Previously submitted model output files must not be removed. \n 'model-output/team1-goodmodel/2022-10-15-team1-"| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -1089,7 +1517,7 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ model_metadata_mod     :List of 6
+       $ model_metadata_mod       :List of 6
         ..$ message       : chr "Previously submitted model metadata files must not be removed. \n 'model-metadata/team1-goodmodel.yaml' removed."
         ..$ trace         : NULL
         ..$ parent        : NULL
@@ -1097,92 +1525,92 @@
         ..$ call          : chr "check_pr_modf_del_file"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
-       $ file_exists            :List of 4
+       $ file_exists              :List of 4
         ..$ message       : chr "File exists at path 'model-output/hub-baseline/2022-10-08-hub-baseline.csv'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name              :List of 4
+       $ file_name                :List of 4
         ..$ message       : chr "File name \"2022-10-08-hub-baseline.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location          :List of 4
+       $ file_location            :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid         :List of 4
+       $ round_id_valid           :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format            :List of 4
+       $ file_format              :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists        :List of 4
+       $ metadata_exists          :List of 4
         ..$ message       : chr "Metadata file exists at path 'model-metadata/hub-baseline.yml'. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_read              :List of 4
+       $ file_read                :List of 4
         ..$ message       : chr "File could be read successfully. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_file_read"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_round_id_col     :List of 4
+       $ valid_round_id_col       :List of 4
         ..$ message       : chr "`round_id_col` name is valid. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_valid_round_id_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ unique_round_id        :List of 4
+       $ unique_round_id          :List of 4
         ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_unique_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ match_round_id         :List of 4
+       $ match_round_id           :List of 4
         ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_match_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ colnames               :List of 4
+       $ colnames                 :List of 4
         ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_colnames"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ col_types              :List of 4
+       $ col_types                :List of 4
         ..$ message       : chr "Column data types match hub schema. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_col_types"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ valid_vals             :List of 5
+       $ valid_vals               :List of 5
         ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_values"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ rows_unique            :List of 4
+       $ rows_unique              :List of 4
         ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_rows_unique"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ req_vals               :List of 5
+       $ req_vals                 :List of 5
         ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ missing       : tibble [0 x 6] (S3: tbl_df/tbl/data.frame)
@@ -1195,87 +1623,194 @@
         ..$ call          : chr "check_tbl_values_required"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_valid        :List of 4
+       $ value_col_valid          :List of 4
         ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_non_desc     :List of 5
+       $ value_col_non_desc       :List of 5
         ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ error_tbl     : NULL
         ..$ call          : chr "check_tbl_value_col_ascending"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ value_col_sum1         :List of 4
+       $ value_col_sum1           :List of 4
         ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_value_col_sum1"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_taskid_set:List of 4
+       $ spl_compound_taskid_set  :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_taskid_set"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_compound_tid       :List of 4
+       $ spl_compound_tid         :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_non_compound_tid   :List of 4
+       $ spl_non_compound_tid     :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_non_compound_tid"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ spl_n                  :List of 4
+       $ spl_n                    :List of 4
         ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
         ..$ where         : 'fs_path' chr "hub-baseline/2022-10-08-hub-baseline.csv"
         ..$ call          : chr "check_tbl_spl_n"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
-       $ file_exists_1          :List of 4
+       $ file_exists_1            :List of 4
         ..$ message       : chr "File exists at path 'model-output/team1-goodmodel/2022-10-22-team1-goodmodel.csv'. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_exists"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_name_1            :List of 4
+       $ file_name_1              :List of 4
         ..$ message       : chr "File name \"2022-10-22-team1-goodmodel.csv\" is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_name"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_location_1        :List of 4
+       $ file_location_1          :List of 4
         ..$ message       : chr "File directory name matches `model_id`\n                                           metadata in file name. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_location"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ round_id_valid_1       :List of 4
+       $ round_id_valid_1         :List of 4
         ..$ message       : chr "`round_id` is valid. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_valid_round_id"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ file_format_1          :List of 4
+       $ file_format_1            :List of 4
         ..$ message       : chr "File is accepted hub format. \n "
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_file_format"
         ..$ use_cli_format: logi TRUE
         ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
-       $ metadata_exists_1      :List of 6
+       $ metadata_exists_1        :List of 6
         ..$ message       : chr "Metadata file does not exist at path 'model-metadata/team1-goodmodel.yml' or\n                                 "| __truncated__
         ..$ trace         : NULL
         ..$ parent        : NULL
         ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
         ..$ call          : chr "check_submission_metadata_file_exists"
         ..$ use_cli_format: logi TRUE
-        ..- attr(*, "class")= chr [1:5] "check_error" "hub_check" "rlang_error" "error" ...
+        ..- attr(*, "class")= chr [1:5] "check_failure" "hub_check" "rlang_error" "error" ...
+       $ file_read_1              :List of 4
+        ..$ message       : chr "File could be read successfully. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_file_read"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_round_id_col_1     :List of 4
+        ..$ message       : chr "`round_id_col` name is valid. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_valid_round_id_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ unique_round_id_1        :List of 4
+        ..$ message       : chr "`round_id` column \"origin_date\" contains a single, unique round ID value. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_unique_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ match_round_id_1         :List of 4
+        ..$ message       : chr "All `round_id_col` \"origin_date\" values match submission `round_id` from file name. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_match_round_id"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ colnames_1               :List of 4
+        ..$ message       : chr "Column names are consistent with expected round task IDs and std column names. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_colnames"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ col_types_1              :List of 4
+        ..$ message       : chr "Column data types match hub schema. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_col_types"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ valid_vals_1             :List of 5
+        ..$ message       : chr "`tbl` contains valid values/value combinations.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_values"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ rows_unique_1            :List of 4
+        ..$ message       : chr "All combinations of task ID column/`output_type`/`output_type_id` values are unique. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_rows_unique"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ req_vals_1               :List of 5
+        ..$ message       : chr "Required task ID/output type/output type ID combinations all present.  \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ missing       : tibble [0 x 7] (S3: tbl_df/tbl/data.frame)
+        .. ..$ origin_date   : chr(0) 
+        .. ..$ target        : chr(0) 
+        .. ..$ horizon       : chr(0) 
+        .. ..$ location      : chr(0) 
+        .. ..$ age_group     : chr(0) 
+        .. ..$ output_type   : chr(0) 
+        .. ..$ output_type_id: chr(0) 
+        ..$ call          : chr "check_tbl_values_required"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_valid_1        :List of 4
+        ..$ message       : chr "Values in column `value` all valid with respect to modeling task config. \n "
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_non_desc_1     :List of 5
+        ..$ message       : chr "Values in `value` column are non-decreasing as output_type_ids increase for all unique task ID\n    value/outpu"| __truncated__
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ error_tbl     : NULL
+        ..$ call          : chr "check_tbl_value_col_ascending"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_success" "hub_check" "rlang_message" "message" ...
+       $ value_col_sum1_1         :List of 4
+        ..$ message       : chr "No pmf output types to check for sum of 1. Check skipped."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_value_col_sum1"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_taskid_set_1:List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_taskid_set` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_taskid_set"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_compound_tid_1       :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_non_compound_tid_1   :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_non_compound_tid` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_non_compound_tid"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       $ spl_n_1                  :List of 4
+        ..$ message       : chr "No v3 samples found in model output data to check. Skipping `check_tbl_spl_n` check."
+        ..$ where         : 'fs_path' chr "team1-goodmodel/2022-10-22-team1-goodmodel.csv"
+        ..$ call          : chr "check_tbl_spl_n"
+        ..$ use_cli_format: logi TRUE
+        ..- attr(*, "class")= chr [1:5] "check_info" "hub_check" "rlang_message" "message" ...
+       - attr(*, "class")= chr [1:2] "hub_validations" "list"
 
 # validate_pr handles errors in determining submission window & file renaming
 

--- a/tests/testthat/test-validate_pr.R
+++ b/tests/testthat/test-validate_pr.R
@@ -63,6 +63,10 @@ test_that("validate_pr flags modifications and deletions in PR", {
     branch = "test-mod-del"
   )
 
+  # This checks that removed metadata and model-output files are detected and
+  # flagged as check errors.
+  # It also checks that missing metadata files do not cause early return
+  # of submission validation of model output file.
   mod_checks_error <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,
@@ -90,6 +94,10 @@ test_that("validate_pr flags modifications and deletions in PR", {
     )
   )
 
+  # This checks that removed metadata and model-output files are detected and
+  # flagged as check failure.
+  # It also checks that missing metadata files do not cause early return
+  # of submission validation of model output file.
   mod_checks_warn <- suppressMessages(
     validate_pr(
       hub_path = temp_hub,


### PR DESCRIPTION
Downgrade missing metadata file when checking model output submission to `<check_failure>` and remove early return. 

Resolves #138