### PR TITLE
Support specifying whether v4 output types are required via `is_required` property

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Re-exported functions useful for modelers (#149):
   - `hubUtils::read_config()` and `hubUtils::read_config_file()` for reading in hub configuration files.
   - `hubData::create_hub_schema()` and `hubData::coerce_to_hub_schema()` for creating and coercing data to the hub schema.
+* v4 config supported (#156, #159).
 
 # hubValidations 0.8.0
 

--- a/R/check_tbl_values_required.R
+++ b/R/check_tbl_values_required.R
@@ -7,7 +7,6 @@
 #' @export
 check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
                                       derived_task_ids = NULL) {
-  # browser()
   tbl[["value"]] <- NULL
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
 
@@ -49,7 +48,7 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
     derived_task_ids = derived_task_ids
   )
 
-  tbl <- join_tbl_to_model_task(full, tbl)
+  tbl <- join_tbl_to_model_task(full, tbl, subset_to_tbl_cols = TRUE)
 
   missing_df <- purrr::pmap(
     combine_mt_inputs(tbl, req, full),

--- a/R/check_tbl_values_required.R
+++ b/R/check_tbl_values_required.R
@@ -7,18 +7,32 @@
 #' @export
 check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
                                       derived_task_ids = NULL) {
+  # browser()
   tbl[["value"]] <- NULL
   config_tasks <- hubUtils::read_config(hub_path, "tasks")
+
   if (hubUtils::is_v3_config(config_tasks)) {
     tbl[tbl$output_type == "sample", "output_type_id"] <- NA
   }
   if (!is.null(derived_task_ids)) {
     tbl[, derived_task_ids] <- NA_character_
   }
+  is_v4 <- hubUtils::version_gte("v4.0.0", config = config_tasks)
+  if (is_v4) {
+    output_types <- get_submission_required_output_types(
+      tbl, config_tasks, round_id
+    )
+    force_output_types <- TRUE
+  } else {
+    output_types <- NULL
+    force_output_types <- FALSE
+  }
   req <- expand_model_out_grid(
     config_tasks,
     round_id = round_id,
+    output_types = output_types,
     required_vals_only = TRUE,
+    force_output_types = force_output_types,
     all_character = TRUE,
     bind_model_tasks = FALSE,
     derived_task_ids = derived_task_ids
@@ -27,6 +41,7 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
   full <- expand_model_out_grid(
     config_tasks,
     round_id = round_id,
+    output_types = output_types,
     required_vals_only = FALSE,
     all_character = TRUE,
     as_arrow_table = FALSE,
@@ -34,10 +49,7 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
     derived_task_ids = derived_task_ids
   )
 
-  tbl <- purrr::map(
-    full,
-    ~ dplyr::inner_join(.x, tbl, by = names(tbl))[, names(tbl)]
-  )
+  tbl <- join_tbl_to_model_task(full, tbl)
 
   missing_df <- purrr::pmap(
     combine_mt_inputs(tbl, req, full),
@@ -341,4 +353,8 @@ combine_mt_inputs <- function(tbl, req, full) {
     req[keep_mt],
     full[keep_mt]
   )
+}
+
+is_zero_tbl <- function(tbl) {
+  isTRUE(ncol(tbl) == 0L)
 }

--- a/R/check_tbl_values_required.R
+++ b/R/check_tbl_values_required.R
@@ -5,6 +5,12 @@
 #' @inherit check_tbl_colnames params
 #' @inherit check_tbl_col_types return
 #' @export
+#' @details
+#' Note that it is **necessary for `derived_task_ids` to be specified if any of
+#' the task IDs derived task IDs depend on have required values**. If this is the
+#' case and derived task IDs are not specified, the dependent nature of derived
+#' task ID values will result in **false validation errors when validating
+#' required values**.
 check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
                                       derived_task_ids = NULL) {
   tbl[["value"]] <- NULL

--- a/R/check_tbl_values_required.R
+++ b/R/check_tbl_values_required.R
@@ -24,11 +24,21 @@ check_tbl_values_required <- function(tbl, round_id, file_path, hub_path,
   }
   is_v4 <- hubUtils::version_gte("v4.0.0", config = config_tasks)
   if (is_v4) {
+    # In v4, whether an output type is optional is determined by `is_required`, not
+    # by values in `optional` vs `required` properties and all output type IDs are
+    # stored in the required property.
+    # Also, in v4, if an optional output type is submitted, all output type IDs
+    # associated with it become required.
+    # To support back-compatibility and use existing infrastructure we need to:
+    # 1. Determine the output types that are are being submitted
     output_types <- get_submission_required_output_types(
       tbl, config_tasks, round_id
     )
+    # 2. Force all output types being submitted to be required, regardless of whether
+    # they are optional in the config.
     force_output_types <- TRUE
   } else {
+    # For pre v4 configs, we use the legacy settings and rules.
     output_types <- NULL
     force_output_types <- FALSE
   }

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -234,7 +234,7 @@ expand_model_out_grid <- function(config_tasks,
   config_tid <- hubUtils::get_config_tid(config_tasks = config_tasks)
 
   output_type_l <- subset_round_output_types(round_config, output_types) %>%
-    extract_rnd_output_type_ids(config_tid, force_output_types) %>%
+    extract_round_output_type_ids(config_tid, force_output_types) %>%
     process_grid_inputs(required_vals_only = required_vals_only) %>%
     purrr::map(~ purrr::compact(.x))
 
@@ -591,7 +591,7 @@ get_sample_n <- function(x, config_tid) {
 # for back-compatibility with schema versions < v2.0.0. Returns a list of
 # `required` and `optional` or just `required` vectors of values as appropriate for
 # each output type in each model task in the round.
-extract_rnd_output_type_ids <- function(x, config_tid, force_output_types = FALSE) {
+extract_round_output_type_ids <- function(x, config_tid, force_output_types = FALSE) {
   purrr::map(x, ~ extract_mt_output_type_ids(.x, config_tid, force_output_types))
 }
 # Extract the output_type_id values from a model_task object.

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -618,11 +618,9 @@ extract_mt_output_type_ids <- function(x, config_tid, force_output_types = FALSE
 }
 
 pre_v4_std <- function(output_type_ids) {
-  isTRUE(
-    setequal(
-      names(output_type_ids),
-      c("required", "optional")
-    )
+  setequal(
+    names(output_type_ids),
+    c("required", "optional")
   )
 }
 

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -619,9 +619,9 @@ extract_mt_output_type_ids <- function(x, config_tid, force_output_types = FALSE
 
 pre_v4_std <- function(output_type_ids) {
   isTRUE(
-    all.equal(
-      sort(names(output_type_ids)),
-      sort(c("required", "optional"))
+    setequal(
+      names(output_type_ids),
+      c("required", "optional")
     )
   )
 }

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -233,7 +233,7 @@ expand_model_out_grid <- function(config_tasks,
   # retired
   config_tid <- hubUtils::get_config_tid(config_tasks = config_tasks)
 
-  output_type_l <- subset_rnd_output_types(round_config, output_types) %>%
+  output_type_l <- subset_round_output_types(round_config, output_types) %>%
     extract_rnd_output_type_ids(config_tid, force_output_types) %>%
     process_grid_inputs(required_vals_only = required_vals_only) %>%
     purrr::map(~ purrr::compact(.x))
@@ -268,7 +268,7 @@ expand_model_out_grid <- function(config_tasks,
 # Subset output types according to `output_types` from all model_task objects in
 # a round. If `output_types` is `NULL`, all output types for each model task are
 # returned.
-subset_rnd_output_types <- function(round_config, output_types) {
+subset_round_output_types <- function(round_config, output_types) {
   purrr::map(
     round_config[["model_tasks"]],
     ~ subset_mt_output_types(.x, output_types)
@@ -586,7 +586,7 @@ get_sample_n <- function(x, config_tid) {
 
 
 # Extract the output_type_id values for each model_task object in a round.
-# Input should be the output of subset_rnd_output_types.
+# Input should be the output of subset_round_output_types.
 # config_tid is the name of the output_type_id column in the config schema used
 # for back-compatibility with schema versions < v2.0.0. Returns a list of
 # `required` and `optional` or just `required` vectors of values as appropriate for

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -46,7 +46,7 @@
 #' If all output types are requested however (i.e. when `output_types = NULL`) and
 #' they are all optional, a grid of required task ID values only will be returned.
 #' However, whenever `force_output_types = TRUE`, all output types are treated as
-#' required.rf v];lfgiuy0
+#' required.
 #' @inheritParams hubData::coerce_to_hub_schema
 #' @details
 #' When a round is set to `round_id_from_variable: true`,

--- a/R/expand_model_out_grid.R
+++ b/R/expand_model_out_grid.R
@@ -635,12 +635,16 @@ is_required_output_type <- function(output_type) {
 }
 
 std_output_type_ids <- function(output_type_ids) {
-  has_output_type_ids <- !is.null(output_type_ids)
-  # pre v4 configs have both `required` and `optional` fields.
-  pre_v4 <- pre_v4_std(output_type_ids)
-  # Valid output type id configurations cannot be `NULL` and be pre v4 specification
-  # (i.e. have both `required` and `optional` fields.
-  has_output_type_ids && pre_v4
+  # Valid output type id configurations cannot be `NULL` . This is the situation
+  # in sample output types which are configured through a output_type_id_params
+  # property
+  no_output_type_ids <- is.null(output_type_ids)
+  if (no_output_type_ids) {
+    return(FALSE)
+  }
+  # pre v4 configs have standard format (i.e. both `required` and `optional` fields.)
+  # which is the format we are standardising to
+  pre_v4_std(output_type_ids)
 }
 
 standardise_output_types_ids <- function(output_type_ids, is_required) {

--- a/R/match_tbl_to_model_task.R
+++ b/R/match_tbl_to_model_task.R
@@ -40,10 +40,20 @@ match_tbl_to_model_task <- function(tbl, config_tasks, round_id,
     output_types = output_types,
     derived_task_ids = derived_task_ids
   ) %>%
-    purrr::map(\(.x) {
-      if (nrow(.x) == 0L) {
-        return(NULL)
+    join_model_task(tbl)
+}
+
+join_tbl_to_model_task  <- function(full, tbl) {
+  purrr::map(
+    full,
+    ~ {
+      # If expanded grid is zero tbl, return NULL
+      if (is_zero_tbl(.x)) {
+        return(.x)
       }
-      dplyr::inner_join(.x, tbl, by = join_cols)
-    })
+      # Otherwise join tbl to model task full expanded grids, splitting the submitted tbl
+      # across modeling task
+      dplyr::inner_join(.x, tbl, by = names(tbl))[, names(tbl)]
+    }
+  )
 }

--- a/R/match_tbl_to_model_task.R
+++ b/R/match_tbl_to_model_task.R
@@ -42,12 +42,12 @@ match_tbl_to_model_task <- function(tbl, config_tasks, round_id,
     join_tbl_to_model_task(tbl, subset_to_tbl_cols = FALSE)
 }
 
-join_tbl_to_model_task  <- function(full, tbl, subset_to_tbl_cols = TRUE) {
+join_tbl_to_model_task <- function(full, tbl, subset_to_tbl_cols = TRUE) {
   cols <- names(tbl)
   join_cols <- cols[cols != "value"]
   purrr::map(
     full,
-    ~ {
+    \(.x, join_cols) {
       # If expanded grid is zero tbl, return NULL
       if (is_zero_tbl(.x)) {
         return(NULL)
@@ -59,6 +59,6 @@ join_tbl_to_model_task  <- function(full, tbl, subset_to_tbl_cols = TRUE) {
         match_tbl <- match_tbl[, join_cols]
       }
       match_tbl
-    }
+    }, join_cols = join_cols
   )
 }

--- a/R/utils-output_types.R
+++ b/R/utils-output_types.R
@@ -1,0 +1,21 @@
+get_rnd_required_output_type_names <- function(config_tasks, round_id) {
+  is_required <- get_round_output_types(config_tasks, round_id) |>
+    purrr::flatten() |>
+    purrr::map_lgl(~ is_required_output_type(.x))
+
+  names(is_required)[is_required] |> unique()
+}
+
+get_submission_required_output_types <- function(tbl, config_tasks,
+                                                 round_id) {
+  tbl_output_types <- get_tbl_output_types(tbl)
+  required_output_types <- get_rnd_required_output_type_names(
+    config_tasks,
+    round_id
+  )
+  unique(c(tbl_output_types, required_output_types))
+}
+
+get_tbl_output_types <- function(tbl) {
+  unique(tbl[["output_type"]])
+}

--- a/R/utils-output_types.R
+++ b/R/utils-output_types.R
@@ -1,4 +1,4 @@
-get_rnd_required_output_type_names <- function(config_tasks, round_id) {
+get_round_required_output_type_names <- function(config_tasks, round_id) {
   is_required <- get_round_output_types(config_tasks, round_id) |>
     purrr::flatten() |>
     purrr::map_lgl(~ is_required_output_type(.x))
@@ -9,7 +9,7 @@ get_rnd_required_output_type_names <- function(config_tasks, round_id) {
 get_submission_required_output_types <- function(tbl, config_tasks,
                                                  round_id) {
   tbl_output_types <- get_tbl_output_types(tbl)
-  required_output_types <- get_rnd_required_output_type_names(
+  required_output_types <- get_round_required_output_type_names(
     config_tasks,
     round_id
   )

--- a/R/validate_model_data.R
+++ b/R/validate_model_data.R
@@ -13,7 +13,7 @@
 #' task ID values will result in **false validation errors when validating
 #' required values**.
 #'
-#' ### Details of checks performed by `validate_model_data()`
+#' Details of checks performed by `validate_model_data()`
 #'
 #' ```{r, echo = FALSE}
 #' arrow::read_csv_arrow(system.file("check_table.csv", package = "hubValidations")) %>%

--- a/R/validate_model_data.R
+++ b/R/validate_model_data.R
@@ -7,7 +7,14 @@
 #' @inherit validate_model_file return
 #' @export
 #' @details
-#' Details of checks performed by `validate_model_data()`
+#' Note that it is **necessary for `derived_task_ids` to be specified if any of
+#' the task IDs derived task IDs depend on have required values**. If this is the
+#' case and derived task IDs are not specified, the dependent nature of derived
+#' task ID values will result in **false validation errors when validating
+#' required values**.
+#'
+#' ### Details of checks performed by `validate_model_data()`
+#'
 #' ```{r, echo = FALSE}
 #' arrow::read_csv_arrow(system.file("check_table.csv", package = "hubValidations")) %>%
 #' dplyr::filter(.data$`parent fun` == "validate_model_data", !.data$optional) %>%

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -23,6 +23,7 @@
 #' @inheritParams validate_model_file
 #' @inheritParams validate_submission
 #' @details
+#'
 #' Only model output and model metadata files are individually validated using
 #' `validate_submission()` or `validate_model_metadata()` respectively although
 #' as part of checks, hub config files are also validated.
@@ -48,6 +49,12 @@
 #' to `FALSE`. This only relates to hubs/rounds where submission windows are
 #' determined relative to a reference date and not when explicit submission
 #' window start and end dates are provided in the config.
+#'
+#' Finally, note that it is **necessary for `derived_task_ids` to be specified if any of
+#' the task IDs derived task IDs depend on have required values**. If this is the
+#' case and derived task IDs are not specified, the dependent nature of derived
+#' task ID values will result in **false validation errors when validating
+#' required values**.
 #'
 #' ### Checks on model output files
 #'

--- a/R/validate_submission.R
+++ b/R/validate_submission.R
@@ -20,7 +20,13 @@
 #' provided in the hub's config.
 #' @export
 #' @details
-#' Details of checks performed by `validate_submission()`
+#' Note that it is **necessary for `derived_task_ids` to be specified if any of
+#' the task IDs derived task IDs depend on have required values**. If this is the
+#' case and derived task IDs are not specified, the dependent nature of derived
+#' task ID values will result in **false validation errors when validating
+#' required values**.
+#'
+#' ### Details of checks performed by `validate_submission()`
 #' ```{r, echo = FALSE}
 #' arrow::read_csv_arrow(system.file("check_table.csv", package = "hubValidations")) %>%
 #' dplyr::filter(.data$`parent fun` != "validate_model_metadata", !.data$optional) %>%

--- a/R/validate_submission.R
+++ b/R/validate_submission.R
@@ -26,7 +26,8 @@
 #' task ID values will result in **false validation errors when validating
 #' required values**.
 #'
-#' ### Details of checks performed by `validate_submission()`
+#' Details of checks performed by `validate_submission()`
+#'
 #' ```{r, echo = FALSE}
 #' arrow::read_csv_arrow(system.file("check_table.csv", package = "hubValidations")) %>%
 #' dplyr::filter(.data$`parent fun` != "validate_model_metadata", !.data$optional) %>%

--- a/man/check_tbl_values_required.Rd
+++ b/man/check_tbl_values_required.Rd
@@ -48,3 +48,10 @@ Returned object also inherits from subclass \verb{<hub_check>}.
 Check all required task ID/output type/output type ID value combinations present
 in model data.
 }
+\details{
+Note that it is \strong{necessary for \code{derived_task_ids} to be specified if any of
+the task IDs derived task IDs depend on have required values}. If this is the
+case and derived task IDs are not specified, the dependent nature of derived
+task ID values will result in \strong{false validation errors when validating
+required values}.
+}

--- a/man/expand_model_out_grid.Rd
+++ b/man/expand_model_out_grid.Rd
@@ -96,7 +96,7 @@ requested through \code{output_types}, a zero row grid will be returned.
 If all output types are requested however (i.e. when \code{output_types = NULL}) and
 they are all optional, a grid of required task ID values only will be returned.
 However, whenever \code{force_output_types = TRUE}, all output types are treated as
-required.rf v];lfgiuy0
+required.
 }
 \description{
 Create expanded grid of valid task ID and output type value combinations

--- a/man/expand_model_out_grid.Rd
+++ b/man/expand_model_out_grid.Rd
@@ -8,6 +8,7 @@ expand_model_out_grid(
   config_tasks,
   round_id,
   required_vals_only = FALSE,
+  force_output_types = FALSE,
   all_character = FALSE,
   output_type_id_datatype = c("from_config", "auto", "character", "double", "integer",
     "logical", "Date"),
@@ -32,6 +33,11 @@ contains only a single round.}
 
 \item{required_vals_only}{Logical. Whether to return only combinations of
 Task ID and related output type ID required values.}
+
+\item{force_output_types}{Logical. Whether to force all output types to be required.
+If \code{TRUE}, all output type ID values are treated as required regardless
+of the value of the \code{is_required} property. Useful for creating grids of required
+values for optional output types.}
 
 \item{all_character}{Logical. Whether to return all character column.}
 
@@ -89,6 +95,8 @@ Note that if \code{required_vals_only = TRUE} and an optional output type is
 requested through \code{output_types}, a zero row grid will be returned.
 If all output types are requested however (i.e. when \code{output_types = NULL}) and
 they are all optional, a grid of required task ID values only will be returned.
+However, whenever \code{force_output_types = TRUE}, all output types are treated as
+required.rf v];lfgiuy0
 }
 \description{
 Create expanded grid of valid task ID and output type value combinations
@@ -197,5 +205,37 @@ expand_model_out_grid(config_tasks,
   bind_model_tasks = FALSE,
   output_types = "sample",
   derived_task_ids = "target_end_date"
+)
+# Return only required values
+hub_path <- system.file("testhubs", "v4", "simple", package = "hubUtils")
+config_tasks <- read_config(hub_path)
+# Return required output types and output_types_ids only
+expand_model_out_grid(
+  config_tasks = config_tasks,
+  round_id = "2022-10-22",
+  required_vals_only = TRUE
+)
+# Force all output types to be required
+expand_model_out_grid(
+  config_tasks = config_tasks,
+  round_id = "2022-10-22",
+  required_vals_only = TRUE,
+  force_output_types = TRUE
+)
+# Sub-setting for an optional output type returns an empty data frame
+expand_model_out_grid(
+  config_tasks = config_tasks,
+  round_id = "2022-10-22",
+  output_types = "mean",
+  required_vals_only = TRUE
+)
+# force_output_types on an optional output type forces all output_type_id values
+# to be required
+expand_model_out_grid(
+  config_tasks = config_tasks,
+  round_id = "2022-10-22",
+  output_types = "mean",
+  required_vals_only = TRUE,
+  force_output_types = TRUE
 )
 }

--- a/man/validate_model_data.Rd
+++ b/man/validate_model_data.Rd
@@ -74,7 +74,8 @@ the task IDs derived task IDs depend on have required values}. If this is the
 case and derived task IDs are not specified, the dependent nature of derived
 task ID values will result in \strong{false validation errors when validating
 required values}.
-\subsection{Details of checks performed by \code{validate_model_data()}}{\if{html}{\out{
+
+Details of checks performed by \code{validate_model_data()}\if{html}{\out{
 <table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">
  <thead>
   <tr>
@@ -203,8 +204,6 @@ the compound idx in question. </td>
 </tbody>
 </table>
 }}
-
-}
 }
 \examples{
 hub_path <- system.file("testhubs/simple", package = "hubValidations")

--- a/man/validate_model_data.Rd
+++ b/man/validate_model_data.Rd
@@ -69,7 +69,13 @@ see \href{https://hubverse-org.github.io/hubValidations/articles/hub-validations
 Validate the contents of a submitted model data file
 }
 \details{
-Details of checks performed by \code{validate_model_data()}\if{html}{\out{<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">}}\if{html}{\out{
+Note that it is \strong{necessary for \code{derived_task_ids} to be specified if any of
+the task IDs derived task IDs depend on have required values}. If this is the
+case and derived task IDs are not specified, the dependent nature of derived
+task ID values will result in \strong{false validation errors when validating
+required values}.
+\subsection{Details of checks performed by \code{validate_model_data()}}{\if{html}{\out{
+<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">
  <thead>
   <tr>
    <th style="text-align:left;"> Name </th>
@@ -197,6 +203,8 @@ the compound idx in question. </td>
 </tbody>
 </table>
 }}
+
+}
 }
 \examples{
 hub_path <- system.file("testhubs/simple", package = "hubValidations")

--- a/man/validate_pr.Rd
+++ b/man/validate_pr.Rd
@@ -122,6 +122,12 @@ currently \code{allow_submit_window_mods} will not work correctly and is best se
 to \code{FALSE}. This only relates to hubs/rounds where submission windows are
 determined relative to a reference date and not when explicit submission
 window start and end dates are provided in the config.
+
+Finally, note that it is \strong{necessary for \code{derived_task_ids} to be specified if any of
+the task IDs derived task IDs depend on have required values}. If this is the
+case and derived task IDs are not specified, the dependent nature of derived
+task ID values will result in \strong{false validation errors when validating
+required values}.
 \subsection{Checks on model output files}{
 
 Details of checks performed by \code{validate_submission()}\if{html}{\out{<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">}}\if{html}{\out{

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -93,7 +93,9 @@ the task IDs derived task IDs depend on have required values}. If this is the
 case and derived task IDs are not specified, the dependent nature of derived
 task ID values will result in \strong{false validation errors when validating
 required values}.
-\subsection{Details of checks performed by \code{validate_submission()}\if{html}{\out{<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">}}}{\if{html}{\out{
+
+Details of checks performed by \code{validate_submission()}\if{html}{\out{
+<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">
  <thead>
   <tr>
    <th style="text-align:left;"> Name </th>
@@ -284,8 +286,6 @@ the compound idx in question. </td>
 </tbody>
 </table>
 }}
-
-}
 }
 \examples{
 hub_path <- system.file("testhubs/simple", package = "hubValidations")

--- a/man/validate_submission.Rd
+++ b/man/validate_submission.Rd
@@ -88,7 +88,12 @@ file name, extension, location etc as well as model output data, i.e. the conten
 of the file.
 }
 \details{
-Details of checks performed by \code{validate_submission()}\if{html}{\out{<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">}}\if{html}{\out{
+Note that it is \strong{necessary for \code{derived_task_ids} to be specified if any of
+the task IDs derived task IDs depend on have required values}. If this is the
+case and derived task IDs are not specified, the dependent nature of derived
+task ID values will result in \strong{false validation errors when validating
+required values}.
+\subsection{Details of checks performed by \code{validate_submission()}\if{html}{\out{<table class="table table-striped table-hover table-condensed table-responsive" style="margin-left: auto; margin-right: auto;">}}}{\if{html}{\out{
  <thead>
   <tr>
    <th style="text-align:left;"> Name </th>
@@ -279,6 +284,8 @@ the compound idx in question. </td>
 </tbody>
 </table>
 }}
+
+}
 }
 \examples{
 hub_path <- system.file("testhubs/simple", package = "hubValidations")

--- a/tests/testthat/_snaps/expand_model_out_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_grid.md
@@ -579,6 +579,48 @@
       x "random" is not valid output type.
       i `output_types` must be members of: "sample", "mean", and "pmf"
 
+# force_output_types works as expected
+
+    Code
+      v3_forced
+    Output
+      # A tibble: 4 x 5
+        reference_date location variant output_type output_type_id
+        <date>         <chr>    <chr>   <chr>       <chr>         
+      1 2022-10-22     US       AA      median      <NA>          
+      2 2022-10-22     01       AA      median      <NA>          
+      3 2022-10-22     US       BB      median      <NA>          
+      4 2022-10-22     01       BB      median      <NA>          
+
+---
+
+    Code
+      v3_forced_all
+    Output
+      # A tibble: 20 x 5
+         reference_date location variant output_type output_type_id
+         <date>         <chr>    <chr>   <chr>       <chr>         
+       1 2022-10-22     US       <NA>    pmf         low           
+       2 2022-10-22     01       <NA>    pmf         low           
+       3 2022-10-22     US       <NA>    pmf         moderate      
+       4 2022-10-22     01       <NA>    pmf         moderate      
+       5 2022-10-22     US       <NA>    pmf         high          
+       6 2022-10-22     01       <NA>    pmf         high          
+       7 2022-10-22     US       <NA>    pmf         very high     
+       8 2022-10-22     01       <NA>    pmf         very high     
+       9 2022-10-22     US       AA      mean        <NA>          
+      10 2022-10-22     01       AA      mean        <NA>          
+      11 2022-10-22     US       BB      mean        <NA>          
+      12 2022-10-22     01       BB      mean        <NA>          
+      13 2022-10-22     US       AA      median      <NA>          
+      14 2022-10-22     01       AA      median      <NA>          
+      15 2022-10-22     US       BB      median      <NA>          
+      16 2022-10-22     01       BB      median      <NA>          
+      17 2022-10-22     US       AA      sample      <NA>          
+      18 2022-10-22     01       AA      sample      <NA>          
+      19 2022-10-22     US       BB      sample      <NA>          
+      20 2022-10-22     01       BB      sample      <NA>          
+
 # expand_model_out_grid derived_task_ids ignoring works
 
     Code
@@ -697,4 +739,25 @@
     Condition
       Error in `expand_model_out_grid()`:
       x The length of `compound_taskid_set` (0) must match the number of modeling tasks (2) in the round.
+
+# v4 required output type ID values extracted correctly
+
+    Code
+      suppressWarnings(expand_model_out_grid(config_tasks = config_tasks, round_id = round_id,
+        output_types = "pmf", derived_task_ids = get_derived_task_ids(hub_path)))
+    Output
+      # A tibble: 540 x 7
+         forecast_date target  horizon target_date location output_type output_type_id
+         <date>        <chr>     <int> <date>      <chr>    <chr>       <chr>         
+       1 2023-05-01    wk flu~       2 NA          US       pmf         large_decrease
+       2 2023-05-01    wk flu~       1 NA          US       pmf         large_decrease
+       3 2023-05-01    wk flu~       2 NA          01       pmf         large_decrease
+       4 2023-05-01    wk flu~       1 NA          01       pmf         large_decrease
+       5 2023-05-01    wk flu~       2 NA          02       pmf         large_decrease
+       6 2023-05-01    wk flu~       1 NA          02       pmf         large_decrease
+       7 2023-05-01    wk flu~       2 NA          04       pmf         large_decrease
+       8 2023-05-01    wk flu~       1 NA          04       pmf         large_decrease
+       9 2023-05-01    wk flu~       2 NA          05       pmf         large_decrease
+      10 2023-05-01    wk flu~       1 NA          05       pmf         large_decrease
+      # i 530 more rows
 

--- a/tests/testthat/_snaps/expand_model_out_grid.md
+++ b/tests/testthat/_snaps/expand_model_out_grid.md
@@ -579,7 +579,153 @@
       x "random" is not valid output type.
       i `output_types` must be members of: "sample", "mean", and "pmf"
 
-# force_output_types works as expected
+# force_output_types works as expected with v4
+
+    Code
+      v4_opt_spls
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 0 x 0
+      
+
+---
+
+    Code
+      v4_opt_spls_force
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 4 x 5
+        reference_date location variant output_type output_type_id
+        <date>         <chr>    <chr>   <chr>       <chr>         
+      1 2022-10-22     US       AA      sample      <NA>          
+      2 2022-10-22     01       AA      sample      <NA>          
+      3 2022-10-22     US       BB      sample      <NA>          
+      4 2022-10-22     01       BB      sample      <NA>          
+      
+
+---
+
+    Code
+      v4_opt_spls_force_spl_idx
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 4 x 5
+        reference_date location variant output_type output_type_id
+        <date>         <chr>    <chr>   <chr>       <chr>         
+      1 2022-10-22     US       AA      sample      1             
+      2 2022-10-22     01       AA      sample      2             
+      3 2022-10-22     US       BB      sample      3             
+      4 2022-10-22     01       BB      sample      4             
+      
+
+---
+
+    Code
+      v4_opt_mdn
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 0 x 0
+      
+
+---
+
+    Code
+      v4_opt_mdn_force
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 4 x 5
+        reference_date location variant output_type output_type_id
+        <date>         <chr>    <chr>   <chr>       <chr>         
+      1 2022-10-22     US       AA      median      <NA>          
+      2 2022-10-22     01       AA      median      <NA>          
+      3 2022-10-22     US       BB      median      <NA>          
+      4 2022-10-22     01       BB      median      <NA>          
+      
+
+---
+
+    Code
+      v4_opt_qntl
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 0 x 0
+      
+
+---
+
+    Code
+      v4_opt_qntl_force
+    Output
+      [[1]]
+      # A tibble: 0 x 0
+      
+      [[2]]
+      # A tibble: 23 x 5
+         forecast_date horizon location output_type output_type_id
+         <date>          <int> <chr>    <chr>       <chr>         
+       1 2023-04-24          2 US       quantile    0.01          
+       2 2023-04-24          2 US       quantile    0.025         
+       3 2023-04-24          2 US       quantile    0.05          
+       4 2023-04-24          2 US       quantile    0.1           
+       5 2023-04-24          2 US       quantile    0.15          
+       6 2023-04-24          2 US       quantile    0.2           
+       7 2023-04-24          2 US       quantile    0.25          
+       8 2023-04-24          2 US       quantile    0.3           
+       9 2023-04-24          2 US       quantile    0.35          
+      10 2023-04-24          2 US       quantile    0.4           
+      # i 13 more rows
+      
+
+---
+
+    Code
+      v4_req_only
+    Output
+      # A tibble: 2 x 3
+        forecast_date horizon location
+        <date>          <int> <chr>   
+      1 2023-04-24          2 US      
+      2 2023-04-24          2 US      
+
+---
+
+    Code
+      v4_force_all
+    Output
+      # A tibble: 29 x 5
+         forecast_date horizon location output_type output_type_id
+         <date>          <int> <chr>    <chr>       <chr>         
+       1 2023-04-24          2 US       pmf         large_decrease
+       2 2023-04-24          2 US       pmf         decrease      
+       3 2023-04-24          2 US       pmf         stable        
+       4 2023-04-24          2 US       pmf         increase      
+       5 2023-04-24          2 US       pmf         large_increase
+       6 2023-04-24          2 US       quantile    0.01          
+       7 2023-04-24          2 US       quantile    0.025         
+       8 2023-04-24          2 US       quantile    0.05          
+       9 2023-04-24          2 US       quantile    0.1           
+      10 2023-04-24          2 US       quantile    0.15          
+      # i 19 more rows
+
+# force_output_types works as expected with v3
 
     Code
       v3_forced

--- a/tests/testthat/test-check_tbl_values_required.R
+++ b/tests/testthat/test-check_tbl_values_required.R
@@ -285,8 +285,72 @@ test_that("(#123) check_tbl_values_required works with all optional output types
   )
 })
 
-test_that(" check_tbl_values_required works with v4 hubs", {
-  skip_if_offline()
+test_that("check_tbl_values_required works with v4 hubs", {
+  hub_path <- system.file("testhubs/v4/flusight", package = "hubUtils")
+  file_path <- "hub-ensemble/2023-05-08-hub-ensemble.parquet"
+  round_id <- "2023-05-08"
+  # TODO: Remove suppressWarnings when v4 is released
+  config_tasks <- read_config(hub_path, "tasks") |> suppressWarnings()
+  tbl <- read_model_out_file(file_path, hub_path,
+    coerce_types = "chr"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  tbl_hub <- read_model_out_file(file_path, hub_path,
+    coerce_types = "hub"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  expect_s3_class(
+    check_tbl_values_required(tbl, round_id, file_path, hub_path,
+      derived_task_ids = "target_date"
+    ) |> suppressWarnings(), # TODO: Remove suppressWarnings when v4 is released
+    c("check_success", "hub_check", "rlang_message", "message", "condition"),
+    exact = TRUE
+  )
 
+  missing_required <- check_tbl_values_required(
+    tbl[-(24:25), ], round_id, file_path, hub_path,
+    derived_task_ids = "target_date"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  missing <- missing_required$missing
+  expect_true(nrow(missing) == 2L)
+  expect_equal(
+    missing[, names(missing) != "target_date"],
+    tbl_hub[24:25, !names(tbl_hub) %in% c("target_date", "value")]
+  )
 
+  missing_opt_otid <- check_tbl_values_required(
+    tbl[-(1:2), ],
+    round_id, file_path, hub_path,
+    derived_task_ids = "target_date"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  missing <- missing_opt_otid$missing
+  expect_equal(
+    missing[, names(missing) != "target_date"],
+    tbl_hub[1:2, !names(tbl_hub) %in% c("target_date", "value")]
+  )
+
+  pmf_row <- tbl[24, ]
+  pmf_row$output_type <- "pmf"
+  pmf_row$output_type_id <- "large_decrease"
+  pmf_row$target <- "wk flu hosp rate change"
+  pmf_row$value <- "0.5"
+
+  missing_pmf <- check_tbl_values_required(
+    pmf_row, round_id,
+    file_path, hub_path,
+    derived_task_ids = "target_date"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  expect_equal(
+    missing_pmf$missing$output_type_id,
+    c("decrease", "stable", "increase", "large_increase")
+  )
+
+  pmf_row$horizon <- "1"
+  missing_horizon <- check_tbl_values_required(
+    pmf_row, round_id,
+    file_path, hub_path,
+    derived_task_ids = "target_date"
+  ) |> suppressWarnings() # TODO: Remove suppressWarnings when v4 is released
+  missing <- missing_horizon$missing
+  expect_equal(nrow(missing), 9L)
+  expect_equal(nrow(missing[missing$horizon == 1L, ]), 4L)
+  expect_equal(nrow(missing[missing$horizon == 2L, ]), 5L)
 })

--- a/tests/testthat/test-check_tbl_values_required.R
+++ b/tests/testthat/test-check_tbl_values_required.R
@@ -284,3 +284,9 @@ test_that("(#123) check_tbl_values_required works with all optional output types
     error = TRUE
   )
 })
+
+test_that(" check_tbl_values_required works with v4 hubs", {
+  skip_if_offline()
+
+
+})

--- a/tests/testthat/test-expand_model_out_grid.R
+++ b/tests/testthat/test-expand_model_out_grid.R
@@ -759,24 +759,16 @@ test_that("v4 required output type ID values extracted correctly", {
     ), 0L
   )
 
-  expect_length(
-    expand_model_out_grid(
-      config_tasks = config_tasks,
-      round_id = round_id,
-      output_types = "pmf",
-      required_vals_only = TRUE,
-      force_output_types = TRUE
-    ), 5L
+  force_pmf <-  expand_model_out_grid(
+    config_tasks = config_tasks,
+    round_id = round_id,
+    output_types = "pmf",
+    required_vals_only = TRUE,
+    force_output_types = TRUE
   )
-
+  expect_length(force_pmf, 5L)
   expect_equal(
-    expand_model_out_grid(
-      config_tasks = config_tasks,
-      round_id = round_id,
-      output_types = "pmf",
-      required_vals_only = TRUE,
-      force_output_types = TRUE
-    )$output_type_id,
+    force_pmf$output_type_id,
     c("large_decrease", "decrease", "stable", "increase", "large_increase")
   )
 })

--- a/tests/testthat/test-expand_model_out_grid.R
+++ b/tests/testthat/test-expand_model_out_grid.R
@@ -639,13 +639,13 @@ test_that("v4 point estimate output type IDs extracted correctly as NAs", {
   # TODO: remove suppressWarnings() when schemas v4 is released
   config_tasks <- suppressWarnings(read_config(hub_path = hub_path))
 
-  expect_true(
-    expand_model_out_grid(
-      config_tasks = config_tasks,
-      round_id = round_id,
-      output_types = "mean",
-    )[["output_type_id"]] |> is.na() |> all()
+  point_est_grid <- expand_model_out_grid(
+    config_tasks = config_tasks,
+    round_id = round_id,
+    output_types = "mean",
   )
+  expect_type(point_est_grid$output_type_id, "character")
+  expect_equal(unique(point_est_grid$output_type_id), NA_character_)
 })
 
 test_that("v4 required output type ID values extracted correctly", {

--- a/tests/testthat/test-expand_model_out_grid.R
+++ b/tests/testthat/test-expand_model_out_grid.R
@@ -636,6 +636,7 @@ test_that("v4 point estimate output type IDs extracted correctly as NAs", {
   hub_path <- system.file("testhubs", "v4", "flusight", package = "hubUtils")
   file_name <- "hub-baseline/2023-05-01-hub-baseline.csv"
   round_id <- parse_file_name(file_name)$round_id
+  # TODO: remove suppressWarnings() when schemas v4 is released
   config_tasks <- suppressWarnings(read_config(hub_path = hub_path))
 
   expect_true(

--- a/tests/testthat/testdata/configs/tasks-samples-v4.json
+++ b/tests/testthat/testdata/configs/tasks-samples-v4.json
@@ -1,0 +1,188 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "reference_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22", "2022-10-29", "2022-11-05"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["wk flu hosp rate category"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [0, 1, 2, 3]
+                        },
+                        "location": {
+                            "required": [
+                                "US",
+                                "01"
+                            ],
+                            "optional": [
+                                "02",
+                                "04",
+                                "05"
+                            ]
+                        },
+                        "variant": {
+                            "required": null,
+                            "optional": null
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22", "2022-10-29", "2022-11-05",
+                                "2022-11-12", "2022-11-19", "2022-11-26"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "pmf": {
+                            "output_type_id": {
+                                "required": [
+                                    "low",
+                                    "moderate",
+                                    "high",
+                                    "very high"
+                                ]
+                            },
+                            "is_required": true,
+                            "value": {
+                                "type": "double",
+                                "minimum": 0,
+                                "maximum": 1
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk flu hosp rate category",
+                            "target_name": "week ahead weekly influenza hospitalization rate category",
+                            "target_units": "rate per 100,000 population",
+                            "target_keys": {
+                                "target": [
+                                    "wk flu hosp rate category"
+                                ]
+                            },
+                            "target_type": "ordinal",
+                            "description": "This target represents a categorical severity level for rate of new hospitalizations per week for the week ending [horizon] weeks after the reference_date, on target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                },
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22", "2022-10-29", "2022-11-05"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["wk inc flu hosp"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [0, 1, 2, 3]
+                        },
+                        "location": {
+                            "required": [
+                                "US",
+                                "01"
+                            ],
+                            "optional": [
+                                "02",
+                                "04",
+                                "05"
+                            ]
+                        },
+                        "variant": {
+                            "required": [
+                                "AA",
+                                "BB"
+                            ],
+                            "optional": [
+                                "CC",
+                                "DD"
+                            ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22", "2022-10-29", "2022-11-05",
+                                "2022-11-12", "2022-11-19", "2022-11-26"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "mean": {
+                            "output_type_id": {
+                                "required": null
+                            },
+                            "is_required": true,
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        },
+                        "median": {
+                            "output_type_id": {
+                                "required": null
+                            },
+                            "is_required": false,
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        },
+                        "sample": {
+                            "output_type_id_params": {
+                                "type": "integer",
+                                "min_samples_per_task": 9,
+                                "max_samples_per_task": 10,
+                                "compound_taskid_set" : ["reference_date", "horizon", "location", "variant", "target_end_date"]
+                            },
+                            "is_required": false,
+                            "value": {
+                                "type": "integer",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk inc flu hosp",
+                            "target_name": "incident influenza hospitalizations",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": [
+                                    "wk inc flu hosp"
+                                ]
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of new hospitalizations in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "derived_task_ids": ["target_end_date"],
+            "submissions_due": {
+                "relative_to": "reference_date",
+                "start": -6,
+                "end": -3
+            }
+        }
+    ]
+}

--- a/vignettes/articles/validate-pr.Rmd
+++ b/vignettes/articles/validate-pr.Rmd
@@ -58,7 +58,13 @@ knitr::include_graphics("assets/ga-action-screenshot.png")
 
 ### Ignoring derived task IDs to improve performance
 
-Argument **`derived_task_ids`** allows for the specification of **task IDs that are derived from other task IDs** to be ignored, which **can often lead to a significant improvement in validation performance**.
+Argument **`derived_task_ids`** allows for the specification of **task IDs that are derived from other task IDs** to be ignored. This **can often lead to a significant improvement in validation performance**.
+
+<div class="alert alert-warning" role="alert">
+
+Note that it is **necessary for `derived_task_ids` to be specified if any of the task IDs derived task IDs depend on have required values**. If this is the case and derived task IDs are not specified, the dependent nature of derived task ID values will result in **false validation errors when validating required values**.
+
+</div>
 
 #### What are derived task IDs?
 


### PR DESCRIPTION
This PR resolves #159 and specifically the need to handle the fact that whether an output type is required or not, is now handled by `is_required`  BUT **if an optional `output_type` is submitted, all `output_type_ids` must be present.**

One issue addressed arises from the fact that for v4, all output_type_id values are stored under `required` even if the output type is not required. If not changed, all `output_type_id` values will end up as required. Addressed by assigning all output type ID values to the `optional` property when standardising if output type is `is_required`.

An additional complication arises from the fact that, when an optional output type is having data submitted to, all `output_type_id`s of that output type need to be considered `required`, so no need for the above re-assignment of values. This requires knowledge of output types in the data, something that `expand_model_out_grid()` has not required up to now. To allow for this situation, I've introduced a `force_output_types` logical argument. When `TRUE` any `output_type`s specified in `expand_model_out_grid()` are forced to be required. In v4 checks, I also provide a vector of output types which includes any optional output types that exist in the data.

Finally, I discovered that if a hub has derived task IDs and they depend on task IDs with required values, `derived_task_ids` MUST be specified to avoid false errors when validating required values. As such, I've added a note in the relevant vignette and function docs but suggest it's repeated in https://github.com/hubverse-org/hubDocs/issues/193