### PR TITLE
Release version 0.10.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.9.0.9000
+Version: 0.10.0
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,23 @@
-# hubValidations (development version)
+# hubValidations 0.10.0
 
-* Added `check_tbl_derived_task_id_vals()` check to `validate_model_data()` that ensures that values in derived task ID columns match expected values for the corresponding derived task IDs in the round as defined in `tasks.json` config (#110). Given the dependence of derived task IDs on the values of their source task ID values, the check ignores the combinations of derived task ID values with those of other task IDs and focuses only on identifying values that do not match corresponding accepted values.
-* `submission_tmpl()` gains the `force_output_types` allowing users to force optional output types to be included in a submission template when `required_vals_only = TRUE`. In conjunction with the use of the `output_types` argument, this allows users to create submission templates which include optional output types they plan to submit.
-* `check_tbl_values_required()` no longer reports false positives for v4 hubs, which fixes the bug reported in #177. Evaluation of whether all combinations of required values have been submitted through `check_tbl_values_required()` is now chunked by output type for v4 config and above. This reduces memory pressure and should speed up required value validation in hubs with complex task.json files.
+* Added `check_tbl_derived_task_id_vals()` check to `validate_model_data()`
+  that ensures that values in derived task ID columns match expected values for
+  the corresponding derived task IDs in the round as defined in `tasks.json`
+  config (#110). Given the dependence of derived task IDs on the values of
+  their source task ID values, the check ignores the combinations of derived
+  task ID values with those of other task IDs and focuses only on identifying
+  values that do not match corresponding accepted values.
+* `submission_tmpl()` gains the `force_output_types` allowing users to force
+  optional output types to be included in a submission template when
+  `required_vals_only = TRUE`. In conjunction with the use of the
+  `output_types` argument, this allows users to create submission templates
+  which include optional output types they plan to submit.
+* `check_tbl_values_required()` no longer reports false positives for v4 hubs,
+  which fixes the bug reported in #177. Evaluation of whether all combinations
+  of required values have been submitted through `check_tbl_values_required()`
+  is now chunked by output type for v4 config and above. This reduces memory
+  pressure and should speed up required value validation in hubs with complex
+  task.json files.
 
 # hubValidations 0.9.0
 


### PR DESCRIPTION
This is [the formal release](https://hubverse-org.github.io/hubDevs/articles/release-checklists.html#release-checklist) for hubValidations 0.10.0 which has the following features:

* Added `check_tbl_derived_task_id_vals()` check to `validate_model_data()`
  that ensures that values in derived task ID columns match expected values for
  the corresponding derived task IDs in the round as defined in `tasks.json`
  config (#110). Given the dependence of derived task IDs on the values of
  their source task ID values, the check ignores the combinations of derived
  task ID values with those of other task IDs and focuses only on identifying
  values that do not match corresponding accepted values.
* `submission_tmpl()` gains the `force_output_types` allowing users to force
  optional output types to be included in a submission template when
  `required_vals_only = TRUE`. In conjunction with the use of the
  `output_types` argument, this allows users to create submission templates
  which include optional output types they plan to submit.
* `check_tbl_values_required()` no longer reports false positives for v4 hubs,
  which fixes the bug reported in #177. Evaluation of whether all combinations
  of required values have been submitted through `check_tbl_values_required()`
  is now chunked by output type for v4 config and above. This reduces memory
  pressure and should speed up required value validation in hubs with complex
  task.json files.

The last point is an important bug fix for v4, which affected the FluSight hub yesterday. Anna had fixed it in #178 and informed me that she is off the project today, which is why I am asking one of either @elray1, @nickreich, or @bsweger to add an approving review. 
