### PR TITLE
fix `expect_s3_class()` tests

### DIFF
--- a/tests/testthat/test-check_file_exists.R
+++ b/tests/testthat/test-check_file_exists.R
@@ -4,13 +4,13 @@ test_that("check_file_exists works", {
 
   expect_s3_class(
     check_file_exists(file_path, hub_path),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
 
   file_path <- "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
   expect_s3_class(
     check_file_exists(file_path, hub_path),
-    c("check_error", "rlang_message", "message", "condition")
+    c("check_error")
   )
 
   expect_error(

--- a/tests/testthat/test-check_file_n.R
+++ b/tests/testthat/test-check_file_n.R
@@ -8,7 +8,7 @@ test_that("check_file_n works", {
       file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
       hub_path
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
 
   expect_s3_class(
@@ -16,7 +16,7 @@ test_that("check_file_n works", {
       file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.parquet",
       hub_path
     ),
-    c("check_failure", "hub_check", "rlang_error", "error", "condition")
+    c("check_failure")
   )
 
   expect_snapshot(

--- a/tests/testthat/test-check_file_read.R
+++ b/tests/testthat/test-check_file_read.R
@@ -16,6 +16,6 @@ test_that("check_file_read works", {
         hub_path = hub_path
       )
     ),
-    c("check_error", "hub_check", "rlang_error", "error", "condition")
+    c("check_error")
   )
 })

--- a/tests/testthat/test-check_metadata_file_exists.R
+++ b/tests/testthat/test-check_metadata_file_exists.R
@@ -3,7 +3,7 @@ test_that("check_metadata_file_exists works", {
 
   expect_s3_class(
     check_metadata_file_exists(hub_path, "hub-baseline.yml"),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_exists(hub_path, "hub-baseline.yml")
@@ -11,7 +11,7 @@ test_that("check_metadata_file_exists works", {
 
   expect_s3_class(
     check_metadata_file_exists(hub_path = "random_path", "hub-baseline.yml"),
-    c("check_error", "rlang_error", "error", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_file_exists(hub_path = "random_path", "hub-baseline.yml")
@@ -19,7 +19,7 @@ test_that("check_metadata_file_exists works", {
 
   expect_s3_class(
     check_metadata_file_exists(hub_path = hub_path, "random_path"),
-    c("check_error", "rlang_error", "error", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_file_exists(hub_path = hub_path, "random_path")

--- a/tests/testthat/test-check_metadata_file_ext.R
+++ b/tests/testthat/test-check_metadata_file_ext.R
@@ -1,7 +1,7 @@
 test_that("check_metadata_file_ext works", {
   expect_s3_class(
     check_metadata_file_ext("hub-baseline.yml"),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_ext("hub-baseline.yml")
@@ -9,7 +9,7 @@ test_that("check_metadata_file_ext works", {
 
   expect_s3_class(
     check_metadata_file_ext("hub-baseline.yaml"),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_ext("hub-baseline.yaml")
@@ -17,7 +17,7 @@ test_that("check_metadata_file_ext works", {
 
   expect_s3_class(
     check_metadata_file_ext("hub-baseline.txt"),
-    c("check_error", "rlang_error", "error", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_file_ext("hub-baseline.txt")

--- a/tests/testthat/test-check_metadata_file_name.R
+++ b/tests/testthat/test-check_metadata_file_name.R
@@ -6,7 +6,7 @@ test_that("check_metadata_file_name works", {
       file_path = "hub-baseline.yml",
       hub_path = hub_path
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_name(
@@ -20,7 +20,7 @@ test_that("check_metadata_file_name works", {
       file_path = "hub-baseline-with-model_id.yml",
       hub_path = hub_path
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_name(
@@ -34,7 +34,7 @@ test_that("check_metadata_file_name works", {
       file_path = "hub-baseline-with-wrong-model_id.yml",
       hub_path = hub_path
     ),
-    c("check_error", "rlang_message", "message", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_file_name(
@@ -48,7 +48,7 @@ test_that("check_metadata_file_name works", {
       file_path = "hub-baseline-no-abbrs-or-model_id.yml",
       hub_path = hub_path
     ),
-    c("check_error", "rlang_message", "message", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_file_name(
@@ -62,7 +62,7 @@ test_that("check_metadata_file_name works", {
       file_path = "team1-goodmodel.yaml",
       hub_path = hub_path
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_file_name(

--- a/tests/testthat/test-check_metadata_matches_schema.R
+++ b/tests/testthat/test-check_metadata_matches_schema.R
@@ -6,7 +6,7 @@ test_that("check_metadata_matches_schema works", {
       file_path = "hub-baseline.yml",
       hub_path = hub_path
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_matches_schema(
@@ -20,7 +20,7 @@ test_that("check_metadata_matches_schema works", {
       file_path = "team1-goodmodel.yaml",
       hub_path = hub_path
     ),
-    c("check_error", "rlang_message", "message", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_matches_schema(

--- a/tests/testthat/test-check_metadata_schema_exists.R
+++ b/tests/testthat/test-check_metadata_schema_exists.R
@@ -3,7 +3,7 @@ test_that("check_metadata_schema_exists works", {
 
   expect_s3_class(
     check_metadata_schema_exists(hub_path),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_metadata_schema_exists(hub_path)
@@ -11,7 +11,7 @@ test_that("check_metadata_schema_exists works", {
 
   expect_s3_class(
     check_metadata_schema_exists(hub_path = "random_path"),
-    c("check_error", "rlang_error", "error", "condition")
+    c("check_error")
   )
   expect_snapshot(
     check_metadata_schema_exists(hub_path = "random_path")

--- a/tests/testthat/test-check_submission_metadata_file_exists.R
+++ b/tests/testthat/test-check_submission_metadata_file_exists.R
@@ -6,7 +6,7 @@ test_that("check_metadata_file_exists works", {
       hub_path = hub_path,
       file_path = "hub-baseline/2022-10-01-hub-baseline.csv"
     ),
-    c("check_success", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_snapshot(
     check_submission_metadata_file_exists(
@@ -20,7 +20,7 @@ test_that("check_metadata_file_exists works", {
       hub_path = hub_path,
       file_path = "random-model/2022-10-01-random-model.csv"
     ),
-    c("check_error", "rlang_error", "error", "condition")
+    c("check_failure")
   )
   expect_snapshot(
     check_submission_metadata_file_exists(

--- a/tests/testthat/test-check_tbl_spl_compound_tid.R
+++ b/tests/testthat/test-check_tbl_spl_compound_tid.R
@@ -29,11 +29,11 @@ test_that("check_tbl_spl_compound_tid works", {
   # Ensure other checks pass
   expect_s3_class(
     check_tbl_spl_non_compound_tid(tbl_error, round_id, file_path, hub_path),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_s3_class(
     check_tbl_spl_compound_tid(tbl_error, round_id, file_path, hub_path),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_error")
   )
 })
 

--- a/tests/testthat/test-check_tbl_spl_n.R
+++ b/tests/testthat/test-check_tbl_spl_n.R
@@ -35,14 +35,14 @@ test_that("check_tbl_spl_n works", {
       tbl_const_error, round_id,
       file_path, hub_path
     ),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_s3_class(
     check_tbl_spl_compound_tid(
       tbl_const_error, round_id,
       file_path, hub_path
     ),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_success")
   )
 
 

--- a/tests/testthat/test-check_tbl_spl_non_compound_tid.R
+++ b/tests/testthat/test-check_tbl_spl_non_compound_tid.R
@@ -29,11 +29,11 @@ test_that("check_tbl_spl_non_compound_tid works", {
   # Ensure other checks pass
   expect_s3_class(
     check_tbl_spl_compound_tid(tbl_error, round_id, file_path, hub_path),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_success")
   )
   expect_s3_class(
     check_tbl_spl_n(tbl_error, round_id, file_path, hub_path),
-    c("check_success", "hub_check", "rlang_message", "message", "condition")
+    c("check_success")
   )
 })
 

--- a/tests/testthat/test-check_tbl_values_required.R
+++ b/tests/testthat/test-check_tbl_values_required.R
@@ -140,7 +140,7 @@ test_that(
 
     expect_s3_class(
       check,
-      c("check_failure", "hub_check", "rlang_warning", "warning", "condition")
+      c("check_failure")
     )
 
     # Expect that values for output type IDs "0.1000000000000000055511",
@@ -162,6 +162,7 @@ test_that(
 test_that(
   "check_tbl_values_required works when config contains non required modeling task.",
   {
+    skip("Expectations have changed---update needed. See <https://github.com/hubverse-org/hubValidations/issues/180#issuecomment-2541884074>")
     hub_path <- test_path("testdata/hub-it")
     file_path <- "Tm-Md/2023-11-04-Tm-Md.csv"
     round_id <- "2023-11-04"
@@ -177,7 +178,7 @@ test_that(
         file_path = file_path,
         hub_path = hub_path
       ),
-      c("check_success", "hub_check", "rlang_message", "message", "condition")
+      c("check_success")
     )
   }
 )

--- a/tests/testthat/test-new_hub_validations.R
+++ b/tests/testthat/test-new_hub_validations.R
@@ -2,7 +2,7 @@ test_that("new_hub_validations works", {
   expect_snapshot(str(new_hub_validations()))
   expect_s3_class(
     new_hub_validations(),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
 
@@ -23,6 +23,6 @@ test_that("new_hub_validations works", {
       file_exists = check_file_exists(file_path, hub_path),
       file_name = check_file_name(file_path)
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 })

--- a/tests/testthat/test-validate_model_data.R
+++ b/tests/testthat/test-validate_model_data.R
@@ -8,7 +8,7 @@ test_that("validate_model_data works", {
   )
   expect_s3_class(
     validate_model_data(hub_path, file_path),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   expect_snapshot(

--- a/tests/testthat/test-validate_model_file.R
+++ b/tests/testthat/test-validate_model_file.R
@@ -13,7 +13,7 @@ test_that("validate_model_file works", {
     validate_model_file(hub_path,
       file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv"
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   # File with validation error
@@ -28,7 +28,7 @@ test_that("validate_model_file works", {
     validate_model_file(hub_path,
       file_path = "team1-goodmodel/2022-10-15-team1-goodmodel.csv"
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 })
 

--- a/tests/testthat/test-validate_model_metadata.R
+++ b/tests/testthat/test-validate_model_metadata.R
@@ -9,7 +9,7 @@ test_that("validate_model_metadata works", {
   )
   expect_s3_class(
     validate_model_metadata(hub_path, file_path),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   file_path <- "hub-baseline.yml"
@@ -20,7 +20,7 @@ test_that("validate_model_metadata works", {
   )
   expect_s3_class(
     validate_model_metadata(hub_path, file_path),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   file_path <- "hub-baseline-no-abbrs-or-model_id.yml"
@@ -31,7 +31,7 @@ test_that("validate_model_metadata works", {
   )
   expect_s3_class(
     validate_model_metadata(hub_path, file_path),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   file_path <- "2020-10-06-random-path.csv"
@@ -42,6 +42,6 @@ test_that("validate_model_metadata works", {
   )
   expect_s3_class(
     validate_model_metadata(hub_path, file_path),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 })

--- a/tests/testthat/test-validate_submission.R
+++ b/tests/testthat/test-validate_submission.R
@@ -19,7 +19,7 @@ test_that("validate_submission works", {
       skip_submit_window_check = TRUE,
       skip_check_config = TRUE
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   # File with validation error ----
@@ -39,7 +39,7 @@ test_that("validate_submission works", {
       skip_submit_window_check = TRUE,
       skip_check_config = TRUE
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
   # Wrong submission location & missing data column (age_group)
@@ -58,7 +58,7 @@ test_that("validate_submission works", {
       skip_submit_window_check = TRUE,
       skip_check_config = TRUE
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 
 
@@ -88,7 +88,7 @@ test_that("validate_submission works", {
       file_path = "team1-goodmodel/2022-10-08-team1-goodmodel.csv",
       skip_submit_window_check = TRUE
     ),
-    c("hub_validations", "list")
+    c("hub_validations")
   )
 })
 
@@ -149,7 +149,7 @@ test_that("validate_submission fails when csv cannot be parsed according to sche
       file_path = "hub-baseline/2023-05-01-hub-baseline.csv",
       skip_submit_window_check = TRUE
     )[["file_read"]],
-    c("check_error", "hub_check", "rlang_error", "error", "condition")
+    c("check_error")
   )
 })
 


### PR DESCRIPTION
I believe this might be good to go through commit by commit. 

As described in #180, I've gone through and I've updated the expectations for `expect_s3_class()` to actually test for the classes we expect. I used the following strategy: 

1. if an expectation has `exact = TRUE`, I leave it alone
2. otherwise, I remove all but the first class

The reason why I did not append `exact = TRUE` to every test is because there were several tests that did not contain the "hub_check" class. Moreover, the vast majority of these tests were checking if there was a successful check or not, which the top-level `check_success`, `check_failure`, etc. gives us.

There is one check that is skipped pending further investigation (see https://github.com/hubverse-org/hubValidations/issues/180#issuecomment-2541884074 and https://github.com/hubverse-org/hubValidations/issues/180#issuecomment-2541925238) for the rationale.


This will fix #180
