### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to hubValidations.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/NEWS.md
+++ b/NEWS.md
@@ -145,7 +145,7 @@ Additional useful functionality:
 # hubValidations 0.0.1
 
 * Release stable 0.0.1 version
-* Enforce minimum dependence on latest `hubData` (0.1.0) & `hubAdmin` (0.1.0). This allows for successful validation of submissions to hubs with multiple model tasks, where a given model task might contain non relevant task IDs and both `required` and `optional` properties have been set to `null` in `tasks.json` (#75). See the [relevant section in `hubDocs` documentation](https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#required-and-optional-elements) for more details.
+* Enforce minimum dependence on latest `hubData` (0.1.0) & `hubAdmin` (0.1.0). This allows for successful validation of submissions to hubs with multiple model tasks, where a given model task might contain non relevant task IDs and both `required` and `optional` properties have been set to `null` in `tasks.json` (#75). See the [relevant section in `hubDocs` documentation](https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#required-and-optional-elements) for more details.
 * Improve formatting of current time print in `validate_submission_time()` message by removing decimal seconds and including local time zone.
 
 

--- a/R/check_tbl_spl_compound_taskid_set.R
+++ b/R/check_tbl_spl_compound_taskid_set.R
@@ -33,7 +33,7 @@
 #' - `invalid_tbl_comp_tids`: the names of invalid compound task IDs.
 #'
 #' The name of each element is the index identifying the config modeling task the sample is associated with `mt_id`.
-#' See [hubverse documentation on samples](https://hubverse.io/en/latest/user-guide/sample-output-type.html)
+#' See [hubverse documentation on samples](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html)
 #' for more details.
 #' @export
 check_tbl_spl_compound_taskid_set <- function(

--- a/R/check_tbl_spl_compound_tid.R
+++ b/R/check_tbl_spl_compound_tid.R
@@ -15,7 +15,7 @@
 #' - `output_type_id`: The output type ID of the sample that does not contain a
 #' single, unique value for each compound task ID.
 #' - `values`: The unique values of each compound task ID.
-#' See [hubverse documentation on samples](https://hubverse.io/en/latest/user-guide/sample-output-type.html)
+#' See [hubverse documentation on samples](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html)
 #' for more details.
 #' @export
 check_tbl_spl_compound_tid <- function(tbl, round_id, file_path, hub_path,

--- a/R/check_tbl_spl_n.R
+++ b/R/check_tbl_spl_n.R
@@ -12,7 +12,7 @@
 #' - `max_samples_per_task`: the maximum number of samples required for the compound idx.
 #' - `compound_idx_tbl`: a tibble of the expected structure for samples belonging to
 #' the compound idx.
-#' See [hubverse documentation on samples](https://hubverse.io/en/latest/user-guide/sample-output-type.html)
+#' See [hubverse documentation on samples](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html)
 #' for more details.
 #' @export
 check_tbl_spl_n <- function(tbl, round_id, file_path, hub_path,

--- a/R/check_tbl_spl_non_compound_tid.R
+++ b/R/check_tbl_spl_non_compound_tid.R
@@ -13,7 +13,7 @@
 #' samples in the modeling task.
 #' - `frequent`: The most frequent non-compound task ID value combination
 #' across all samples in the modeling task to which all samples were compared.
-#' See [hubverse documentation on samples](https://hubverse.io/en/latest/user-guide/sample-output-type.html)
+#' See [hubverse documentation on samples](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html)
 #' for more details.
 #' @export
 check_tbl_spl_non_compound_tid <- function(tbl, round_id, file_path, hub_path,

--- a/R/parse_file_name.R
+++ b/R/parse_file_name.R
@@ -68,7 +68,8 @@ split_filename <- function(file_name, file_type) {
       "Could not parse file name {.path {file_name}} for submission metadata.
       Please consult
       {.href [documentation on file name requirements
-      ](https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure)} for correct metadata parsing."
+      ](https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure)} 
+      for correct metadata parsing."
     )
   }
   if (file_type == "model_metadata") {

--- a/R/parse_file_name.R
+++ b/R/parse_file_name.R
@@ -68,7 +68,7 @@ split_filename <- function(file_name, file_type) {
       "Could not parse file name {.path {file_name}} for submission metadata.
       Please consult
       {.href [documentation on file name requirements
-      ](https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure)} for correct metadata parsing."
+      ](https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure)} for correct metadata parsing."
     )
   }
   if (file_type == "model_metadata") {
@@ -114,8 +114,8 @@ validate_filename_pattern <- function(file_name, file_type,
 
 
   info_url <- switch(file_type, # nolint: object_usage_linter
-    model_output = "https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure",
-    model_metadata = "https://hubverse.io/en/latest/user-guide/model-metadata.html#directory-structure"
+    model_output = "https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure",
+    model_metadata = "https://docs.hubverse.io/en/latest/user-guide/model-metadata.html#directory-structure"
   )
 
   if (!grepl(pattern, file_name)) {
@@ -141,7 +141,7 @@ validate_compression_ext <- function(compression_ext, call = rlang::caller_env()
       c("x" = "Compression extension {.val {compression_ext}} is not valid.
       Must be one of {.val {compress_codec}}.
       Please consult {.href [documentation on file name requirements
-      ](https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure)}
+      ](https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure)}
       for details."),
       call = call
     )

--- a/README.Rmd
+++ b/README.Rmd
@@ -62,7 +62,7 @@ Please note that the hubValidations package is released with a [Contributor Code
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to hubValidations](.github/CONTRIBUTING.md).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to hubValidations](.github/CONTRIBUTING.md).
 
 ### Contributing new check functions
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ contributing to this project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to hubValidations](.github/CONTRIBUTING.md).
 
 ### Contributing new check functions

--- a/inst/testhubs/samples/model-metadata/README.md
+++ b/inst/testhubs/samples/model-metadata/README.md
@@ -13,9 +13,9 @@ folder with a template that submitting teams can copy and update for their
 own models. Because some model metadata fields may be hub-specific, creators 
 of the hub are encouraged to create their template by:
 
-- adding the [Hubverse template model metadata file](https://hubverse.io/en/latest/user-guide/model-metadata.html#template-metadata-schema-file) to `model-metadata` 
+- adding the [Hubverse template model metadata file](https://docs.hubverse.io/en/latest/user-guide/model-metadata.html#template-metadata-schema-file) to `model-metadata` 
 - modifying the template model metadata file to include any hub-specific fields
-- ensuring that the above changes are consistent with [Hubverse model metadata guidelines](https://hubverse.io/en/latest/format/model-metadata.html).
+- ensuring that the above changes are consistent with [Hubverse model metadata guidelines](https://docs.hubverse.io/en/latest/format/model-metadata.html).
 
 
 The instructions below provide detail about the [data

--- a/inst/testhubs/samples/model-output/README.md
+++ b/inst/testhubs/samples/model-output/README.md
@@ -1,3 +1,3 @@
 # Model outputs folder
 
-This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://hubverse.io/en/latest/user-guide/model-output.html).
+This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://docs.hubverse.io/en/latest/user-guide/model-output.html).

--- a/man/check_tbl_spl_compound_taskid_set.Rd
+++ b/man/check_tbl_spl_compound_taskid_set.Rd
@@ -76,6 +76,6 @@ task config.
 }
 
 The name of each element is the index identifying the config modeling task the sample is associated with \code{mt_id}.
-See \href{https://hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
+See \href{https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
 for more details.
 }

--- a/man/check_tbl_spl_compound_tid.Rd
+++ b/man/check_tbl_spl_compound_tid.Rd
@@ -62,7 +62,7 @@ one for each sample failing validation, with the following structure:
 \item \code{output_type_id}: The output type ID of the sample that does not contain a
 single, unique value for each compound task ID.
 \item \code{values}: The unique values of each compound task ID.
-See \href{https://hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
+See \href{https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
 for more details.
 }
 }

--- a/man/check_tbl_spl_n.Rd
+++ b/man/check_tbl_spl_n.Rd
@@ -64,7 +64,7 @@ one for each compound_idx failing validation, with the following structure:
 \item \code{max_samples_per_task}: the maximum number of samples required for the compound idx.
 \item \code{compound_idx_tbl}: a tibble of the expected structure for samples belonging to
 the compound idx.
-See \href{https://hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
+See \href{https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
 for more details.
 }
 }

--- a/man/check_tbl_spl_non_compound_tid.Rd
+++ b/man/check_tbl_spl_non_compound_tid.Rd
@@ -65,7 +65,7 @@ non-compound task ID value combination across all
 samples in the modeling task.
 \item \code{frequent}: The most frequent non-compound task ID value combination
 across all samples in the modeling task to which all samples were compared.
-See \href{https://hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
+See \href{https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html}{hubverse documentation on samples}
 for more details.
 }
 }

--- a/tests/testthat/_snaps/parse_file_name.md
+++ b/tests/testthat/_snaps/parse_file_name.md
@@ -88,7 +88,7 @@
       parse_file_name("hubBaseline.yml", file_type = "model_metadata")
     Condition
       Error in `parse_file_name()`:
-      x File name 'hubBaseline' does not match expected pattern of [team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://hubverse.io/en/latest/user-guide/model-metadata.html#directory-structure>) for details.
+      x File name 'hubBaseline' does not match expected pattern of [team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://docs.hubverse.io/en/latest/user-guide/model-metadata.html#directory-structure>) for details.
 
 # parse_file_name fails correctly
 
@@ -96,7 +96,7 @@
       parse_file_name("model-output/team1-goodmodel/2022-10-08-team1_goodmodel.csv")
     Condition
       Error in `parse_file_name()`:
-      x File name '2022-10-08-team1_goodmodel' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
+      x File name '2022-10-08-team1_goodmodel' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
 
 ---
 
@@ -196,5 +196,5 @@
         "model-output/team1-goodmodel/2022-10-08-team1-goodmodel.gzipr.parquet")
     Condition
       Error in `parse_file_name()`:
-      x Compression extension "gzipr" is not valid. Must be one of "snappy", "gzip", "gz", "brotli", "zstd", "lz4", "lzo", and "bz2". Please consult documentation on file name requirements (<https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
+      x Compression extension "gzipr" is not valid. Must be one of "snappy", "gzip", "gz", "brotli", "zstd", "lz4", "lzo", and "bz2". Please consult documentation on file name requirements (<https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -4,7 +4,7 @@
       get_file_round_id(file_path = "team1-goodmodel/2022-10-08-team-1-goodmodel.csv")
     Condition
       Error in `parse_file_name()`:
-      x File name '2022-10-08-team-1-goodmodel' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
+      x File name '2022-10-08-team-1-goodmodel' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
 
 # get_file_* utils work
 

--- a/tests/testthat/_snaps/validate_model_data.md
+++ b/tests/testthat/_snaps/validate_model_data.md
@@ -346,7 +346,7 @@
       validate_model_data(hub_path, file_path = "random-path.csv")
     Condition
       Error in `parse_file_name()`:
-      x File name 'random-path' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
+      x File name 'random-path' does not match expected pattern of [round_id]-[team_abbr]-[model_abbr]. Please consult documentation on file name requirements (<https://docs.hubverse.io/en/latest/user-guide/model-output.html#directory-structure>) for details.
 
 # validate_model_data with v3 sample data works
 

--- a/tests/testthat/testdata/hub-it/model-output/README.md
+++ b/tests/testthat/testdata/hub-it/model-output/README.md
@@ -1,3 +1,3 @@
 # Model outputs folder
 
-This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://hubverse.io/en/latest/format/model-output.html).
+This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://docs.hubverse.io/en/latest/format/model-output.html).

--- a/vignettes/articles/validate-pr.Rmd
+++ b/vignettes/articles/validate-pr.Rmd
@@ -97,7 +97,7 @@ Ignoring derived task IDs means that the validity of derived task ID value combi
 
 ### Skipping submission window checks
 
-Most hubs require that model output files for a given round are submitted within a submission window [defined in the `"submission_due"` property of the `tasks.json` hub config file](https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#setting-up-submissions-due). 
+Most hubs require that model output files for a given round are submitted within a submission window [defined in the `"submission_due"` property of the `tasks.json` hub config file](https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#setting-up-submissions-due). 
 
 `validate_pr()` includes submission window checks for model output files and returns a `<error/check_failure>` condition class object if a file is submitted outside the accepted submission window.
 
@@ -157,7 +157,7 @@ Is ignored when checking model metadata files as well as when `file_modification
  If hub submission window reference dates do not match round IDs in file paths, currently `allow_submit_window_mods` will not work correctly and is best set to `FALSE`. 
  This only relates to hubs/rounds where submission windows are determined relative to a reference date and not when explicit submission window start and end dates are provided in the config. 
  
- For more details on submission window config see [Setting up `"submission_due"`](https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#setting-up-submissions-due) in the hubverse hubDocs.
+ For more details on submission window config see [Setting up `"submission_due"`](https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html#setting-up-submissions-due) in the hubverse hubDocs.
 
 </div>
 


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.