### PR TITLE
Increment version number to 0.12.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.11.0.9000
+Version: 0.12.0
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubValidations (development version)
+# hubValidations 0.12.0
 
 * Added `target_validations` class, a subclass of `hub_validations` designed for target (truth) data validation results (#265).
   - New functions: `new_target_validations()` and `as_target_validations()`


### PR DESCRIPTION
Tests need re-triggering once https://github.com/hubverse-org/hubUtils/pull/245 and https://github.com/hubverse-org/hubData/pull/104 are merged and both `hubUtils` and `hubData` are released and built on r-universe