### PR TITLE
Fix pagination issue in PR file validation

### DIFF
--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -167,7 +167,9 @@ validate_pr <- function(
       pr_files <- gh::gh(
         "/repos/{gh_repo}/pulls/{pr_number}/files",
         gh_repo = gh_repo,
-        pr_number = pr_number
+        pr_number = pr_number,
+        per_page = 100,
+        .limit = Inf
       )
       pr_df <- tibble::tibble(
         filename = purrr::map_chr(pr_files, ~ .x$filename),


### PR DESCRIPTION
### Problem

Fixes #276

The GitHub API paginates results by default, returning only 30 files per page. When validating PRs with more than 30 modified files, only the first 30 files were being fetched and validated. This allowed invalid files to pass validation checks (see #276).

### Solution
Added `per_page = 100` and `.limit = Inf` parameters to the `gh::gh()` call to ensure all modified files are fetched across all pages:
```r
pr_files <- gh::gh(
  "/repos/{gh_repo}/pulls/{pr_number}/files",
  gh_repo = gh_repo,
  pr_number = pr_number,
  per_page = 100,
  .limit = Inf
)
```

This ensures that regardless of the number of files modified in a PR, all files will be properly validated.

### Testing

I've tested locally with PRs containing > 30 modified files and verified all files are now being validated. Will open an issue to add a formal test in due course but wanted to get this easy fix out the door fast (see https://github.com/hubverse-org/hubValidations/issues/278)
