### PR TITLE
Update tests/snapshots for hubUtils testhub target name changes

### DIFF
--- a/R/new_target_validations.R
+++ b/R/new_target_validations.R
@@ -22,7 +22,7 @@
 #'   target_file_ext_valid = check_target_file_ext_valid(file_path)
 #' )
 #' as_target_validations(x)
-#' file_path <- "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet"
+#' file_path <- "time-series/target=flu_hosp_rate/part-0.parquet"
 #' new_target_validations(
 #'   target_file_name = check_target_file_name(file_path),
 #'   target_file_ext_valid = check_target_file_ext_valid(file_path)

--- a/R/validate_target_data.R
+++ b/R/validate_target_data.R
@@ -37,7 +37,7 @@
 #' )
 #' hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 #' validate_target_data(hub_path,
-#'   file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+#'   file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
 #'   target_type = "time-series"
 #' )
 #' validate_target_data(hub_path,

--- a/R/validate_target_file.R
+++ b/R/validate_target_file.R
@@ -45,7 +45,7 @@
 #' )
 #' hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 #' validate_target_file(hub_path,
-#'   file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet"
+#'   file_path = "time-series/target=flu_hosp_rate/part-0.parquet"
 #' )
 #' validate_target_file(hub_path,
 #'   file_path = "oracle-output/output_type=pmf/part-0.parquet"

--- a/R/validate_target_submission.R
+++ b/R/validate_target_submission.R
@@ -42,7 +42,7 @@
 #' hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 #' validate_target_submission(
 #'   hub_path,
-#'   file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+#'   file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
 #'   target_type = "time-series"
 #' )
 validate_target_submission <- function(

--- a/man/new_target_validations.Rd
+++ b/man/new_target_validations.Rd
@@ -43,7 +43,7 @@ x <- list(
   target_file_ext_valid = check_target_file_ext_valid(file_path)
 )
 as_target_validations(x)
-file_path <- "time-series/target=wk\%20flu\%20hosp\%20rate/part-0.parquet"
+file_path <- "time-series/target=flu_hosp_rate/part-0.parquet"
 new_target_validations(
   target_file_name = check_target_file_name(file_path),
   target_file_ext_valid = check_target_file_ext_valid(file_path)

--- a/man/validate_target_data.Rd
+++ b/man/validate_target_data.Rd
@@ -173,7 +173,7 @@ validate_target_data(hub_path,
 )
 hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 validate_target_data(hub_path,
-  file_path = "time-series/target=wk\%20flu\%20hosp\%20rate/part-0.parquet",
+  file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
   target_type = "time-series"
 )
 validate_target_data(hub_path,

--- a/man/validate_target_file.Rd
+++ b/man/validate_target_file.Rd
@@ -93,7 +93,7 @@ validate_target_file(hub_path,
 )
 hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 validate_target_file(hub_path,
-  file_path = "time-series/target=wk\%20flu\%20hosp\%20rate/part-0.parquet"
+  file_path = "time-series/target=flu_hosp_rate/part-0.parquet"
 )
 validate_target_file(hub_path,
   file_path = "oracle-output/output_type=pmf/part-0.parquet"

--- a/man/validate_target_submission.Rd
+++ b/man/validate_target_submission.Rd
@@ -206,7 +206,7 @@ validate_target_submission(
 hub_path <- system.file("testhubs/v5/target_dir", package = "hubUtils")
 validate_target_submission(
   hub_path,
-  file_path = "time-series/target=wk\%20flu\%20hosp\%20rate/part-0.parquet",
+  file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
   target_type = "time-series"
 )
 }

--- a/tests/testthat/_snaps/validate_target_data.md
+++ b/tests/testthat/_snaps/validate_target_data.md
@@ -38,7 +38,7 @@
       res_ts
     Message
       
-      -- time-series/target=wk%20flu%20hosp%20rate/part-0.parquet ----
+      -- time-series/target=flu_hosp_rate/part-0.parquet ----
       
       v [target_file_read]: target file could be read successfully.
       v [target_tbl_colnames]: Column names are consistent with expected column names for time-series target type data.  Column name validation for time-series data in inference mode is limited. For robust validation, create a 'target-data.json' config file. See `target-data.json` documentation (<https://docs.hubverse.io/en/latest/user-guide/hub-config.html#hub-target-data-configuration-target-data-json-file>)

--- a/tests/testthat/_snaps/validate_target_file.md
+++ b/tests/testthat/_snaps/validate_target_file.md
@@ -28,9 +28,9 @@
       res_ts
     Message
       
-      -- time-series/target=wk%20flu%20hosp%20rate/part-0.parquet ----
+      -- time-series/target=flu_hosp_rate/part-0.parquet ----
       
-      v [target_file_exists]: File exists at path 'target-data/time-series/target=wk%20flu%20hosp%20rate/part-0.parquet'.
+      v [target_file_exists]: File exists at path 'target-data/time-series/target=flu_hosp_rate/part-0.parquet'.
       v [target_partition_file_name]: Hive-style partition file path segments are valid.
       v [target_file_ext]: Hive-partitioned target data file extension is valid.
 

--- a/tests/testthat/_snaps/validate_target_submission.md
+++ b/tests/testthat/_snaps/validate_target_submission.md
@@ -56,7 +56,7 @@
       
       v [valid_config]: All hub config files are valid.
       
-      -- time-series/target=wk%20flu%20hosp%20rate/part-0.parquet ----
+      -- time-series/target=flu_hosp_rate/part-0.parquet ----
       
-      (x) [target_file_exists]: File does not exist at path 'target-data/time-series/target=wk%20flu%20hosp%20rate/part-0.parquet'.
+      (x) [target_file_exists]: File does not exist at path 'target-data/time-series/target=flu_hosp_rate/part-0.parquet'.
 

--- a/tests/testthat/test-check_target_dataset_rows_unique.R
+++ b/tests/testthat/test-check_target_dataset_rows_unique.R
@@ -75,7 +75,7 @@ test_that("check_target_dataset_rows_unique works time-series data", {
     structure(
       list(
         target_end_date = structure(19287, class = "Date"),
-        target = "wk inc flu hosp",
+        target = "flu_hosp_inc",
         location = "02",
         count = 3L
       ),
@@ -114,7 +114,7 @@ test_that("check_target_dataset_rows_unique works time-series data", {
     structure(
       list(
         target_end_date = structure(19287, class = "Date"),
-        target = "wk inc flu hosp",
+        target = "flu_hosp_inc",
         location = "02",
         as_of = structure(20298, class = "Date"),
         count = 3L
@@ -216,7 +216,7 @@ test_that("check_target_dataset_rows_unique works with hive partitioned parquet 
       list(
         target_end_date = structure(19287, class = "Date"),
         location = "02",
-        target = "wk inc flu hosp",
+        target = "flu_hosp_inc",
         count = 3L
       ),
       class = c("tbl_df", "tbl", "data.frame"),
@@ -259,7 +259,7 @@ test_that("check_target_dataset_rows_unique works with hive partitioned parquet 
         target_end_date = structure(19287, class = "Date"),
         location = "02",
         as_of = structure(20298, class = "Date"),
-        target = "wk inc flu hosp",
+        target = "flu_hosp_inc",
         count = 3L
       ),
       class = c("tbl_df", "tbl", "data.frame"),
@@ -341,7 +341,7 @@ test_that("check_target_dataset_rows_unique works on oracle-output data", {
       list(
         location = "US",
         target_end_date = structure(19287, class = "Date"),
-        target = "wk flu hosp rate",
+        target = "flu_hosp_rate",
         output_type = "cdf",
         output_type_id = "1",
         count = 3L
@@ -381,7 +381,7 @@ test_that("check_target_dataset_rows_unique works on oracle-output data", {
       list(
         location = "US",
         target_end_date = structure(19287, class = "Date"),
-        target = "wk flu hosp rate",
+        target = "flu_hosp_rate",
         output_type = "cdf",
         output_type_id = "1",
         count = 4L
@@ -483,7 +483,7 @@ test_that("check_target_dataset_rows_unique works with hive partitioned parquet 
         target_end_date = structure(19287, class = "Date"),
         output_type = "cdf",
         output_type_id = "1",
-        target = "wk flu hosp rate",
+        target = "flu_hosp_rate",
         count = 3L
       ),
       class = c("tbl_df", "tbl", "data.frame"),
@@ -529,7 +529,7 @@ test_that("check_target_dataset_rows_unique works with hive partitioned parquet 
         target_end_date = structure(19287, class = "Date"),
         output_type = "cdf",
         output_type_id = "1",
-        target = "wk flu hosp rate",
+        target = "flu_hosp_rate",
         count = 4L
       ),
       class = c("tbl_df", "tbl", "data.frame"),

--- a/tests/testthat/test-check_target_file_read.R
+++ b/tests/testthat/test-check_target_file_read.R
@@ -53,7 +53,7 @@ test_that("check_target_file_read works with csv data", {
 
   # Break quoting (unclosed quote) ----
   lines <- readLines(source_target_path)
-  lines[3] <- '"2020-01-11,wk inc flu hosp,15,0' # missing closing quote
+  lines[3] <- '"2020-01-11,flu_hosp_inc,15,0' # missing closing quote
   writeLines(lines, target_path)
 
   unclosed_quote_csv <- check_target_file_read(
@@ -204,7 +204,7 @@ test_that("check_target_file_read works on partitioned data", {
   )
 
   # Should read successfully
-  file_path <- "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet"
+  file_path <- "time-series/target=flu_hosp_rate/part-0.parquet"
   valid_partitioned <- check_target_file_read(
     file_path = file_path,
     hub_path = hub_path

--- a/tests/testthat/test-check_target_tbl_coltypes.R
+++ b/tests/testthat/test-check_target_tbl_coltypes.R
@@ -133,14 +133,14 @@ test_that("check_target_tbl_coltypes works with partitioned v6 hub", {
 
   hub_path <- system.file("testhubs/v6/target_dir", package = "hubUtils")
   target_tbl <- read_target_file(
-    "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path
   )
 
   valid_ts <- check_target_tbl_coltypes(
     target_tbl,
     target_type = "time-series",
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path = hub_path
   )
   expect_s3_class(valid_ts, "check_success")
@@ -155,7 +155,7 @@ test_that("check_target_tbl_coltypes works with partitioned v6 hub", {
   invalid_ts <- check_target_tbl_coltypes(
     target_tbl,
     target_type = "time-series",
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path = hub_path
   )
 
@@ -382,14 +382,14 @@ test_that("check_target_tbl_coltypes works with partitioned v6 hub", {
 
   hub_path <- system.file("testhubs/v6/target_dir", package = "hubUtils")
   target_tbl <- read_target_file(
-    "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path
   )
 
   valid_ts <- check_target_tbl_coltypes(
     target_tbl,
     target_type = "time-series",
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path = hub_path
   )
   expect_s3_class(valid_ts, "check_success")
@@ -404,7 +404,7 @@ test_that("check_target_tbl_coltypes works with partitioned v6 hub", {
   invalid_ts <- check_target_tbl_coltypes(
     target_tbl,
     target_type = "time-series",
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     hub_path = hub_path
   )
 

--- a/tests/testthat/test-check_target_tbl_output_type_ids.R
+++ b/tests/testthat/test-check_target_tbl_output_type_ids.R
@@ -53,7 +53,7 @@ test_that("check_target_tbl_output_type_ids works", {
   )
   expect_equal(
     invalid_oo$missing$target,
-    "wk flu hosp rate category"
+    "flu_hosp_rate_cat"
   )
   expect_equal(
     invalid_oo$missing$output_type,
@@ -268,7 +268,7 @@ test_that("check_target_tbl_output_type_ids works with 2 dist targets", {
   )
   expect_equal(
     sort(invalid_dist_2$missing$target),
-    c("wk flu death rate category", "wk flu hosp rate category")
+    c("flu_hosp_rate_cat", "wk flu death rate category")
   )
   expect_equal(
     unique(invalid_dist_2$missing$output_type),

--- a/tests/testthat/test-check_target_tbl_ts_targets.R
+++ b/tests/testthat/test-check_target_tbl_ts_targets.R
@@ -98,7 +98,7 @@ test_that("check_target_tbl_ts_targets works with NULL target_keys", {
   expect_s3_class(invalid_null, "check_error")
   expect_equal(
     cli::ansi_strip(invalid_null$message) |> stringr::str_squish(),
-    "time-series target is not valid. Global target \"wk flu hosp rate category\" inferred from hub config is invalid. Time-series target data not appropriate. Valid time-series targets must be step-ahead and their target type must be one of \"continuous\", \"discrete\", \"binary\", and \"compositional\"." # nolint: line_length_linter
+    "time-series target is not valid. Global target \"flu_hosp_rate_cat\" inferred from hub config is invalid. Time-series target data not appropriate. Valid time-series targets must be step-ahead and their target type must be one of \"continuous\", \"discrete\", \"binary\", and \"compositional\"." # nolint: line_length_linter
   )
 })
 

--- a/tests/testthat/test-check_target_tbl_values.R
+++ b/tests/testthat/test-check_target_tbl_values.R
@@ -50,7 +50,7 @@ test_that("check_target_tbl_values works with time-series data", {
   )
   expect_equal(
     invalid_ts$error_tbl$target,
-    c("wk inc flu hosp", "random_target")
+    c("flu_hosp_inc", "random_target")
   )
 
   # Check that function still works when `target_tbl_chr` has errors in every row and
@@ -160,7 +160,7 @@ test_that("check_target_tbl_values works with oracle-output data", {
   )
   expect_equal(
     invalid_oracle$error_tbl$target,
-    c("wk flu hosp rate", "random_target")
+    c("flu_hosp_rate", "random_target")
   )
   expect_named(
     invalid_oracle$error_tbl,

--- a/tests/testthat/test-read_target_file.R
+++ b/tests/testthat/test-read_target_file.R
@@ -165,7 +165,7 @@ test_that("read_target_file works with split timeseries file.", {
 
   # read in one of the time-series file with hub schema
   file <- read_target_file(
-    "time-series/target-wk_inc_flu_hosp.csv",
+    "time-series/target-flu_hosp_inc.csv",
     dir_hub_path
   )
   expect_s3_class(file, "tbl_df")
@@ -195,7 +195,7 @@ test_that("read_target_file works with split timeseries file.", {
 
   # read in one of the time-series file with all character columns
   chr_file <- read_target_file(
-    "time-series/target-wk_inc_flu_hosp.csv",
+    "time-series/target-flu_hosp_inc.csv",
     dir_hub_path,
     coerce_types = "chr"
   )
@@ -231,7 +231,7 @@ test_that("connect_target_timeseries with HIVE-PARTTIONED data works on local hu
 
   # read in one of the time-series file with hub schema
   file <- read_target_file(
-    "time-series/target=wk%20inc%20flu%20hosp/part-0.parquet",
+    "time-series/target=flu_hosp_inc/part-0.parquet",
     hub_path = dir_hub_path
   )
   expected_dims <- c(33L, 4L)
@@ -261,7 +261,7 @@ test_that("connect_target_timeseries with HIVE-PARTTIONED data works on local hu
   )
   # read in one of the time-series file as all character
   file_chr <- read_target_file(
-    "time-series/target=wk%20inc%20flu%20hosp/part-0.parquet",
+    "time-series/target=flu_hosp_inc/part-0.parquet",
     hub_path = dir_hub_path,
     coerce_types = "chr"
   )
@@ -283,7 +283,7 @@ test_that("connect_target_timeseries with HIVE-PARTTIONED data works on local hu
   arrow::write_dataset(dat, dir, partitioning = "target", format = "csv")
   # read in one of the time-series file with hub schema
   file <- read_target_file(
-    "time-series/target=wk%20inc%20flu%20hosp/part-0.csv",
+    "time-series/target=flu_hosp_inc/part-0.csv",
     hub_path = dir_hub_path
   )
 
@@ -309,7 +309,7 @@ test_that("connect_target_timeseries with HIVE-PARTTIONED data works on local hu
   )
   # read in one of the time-series file as all character
   file_chr <- read_target_file(
-    "time-series/target=wk%20inc%20flu%20hosp/part-0.csv",
+    "time-series/target=flu_hosp_inc/part-0.csv",
     hub_path = dir_hub_path,
     coerce_types = "chr"
   )

--- a/tests/testthat/test-validate_target_data.R
+++ b/tests/testthat/test-validate_target_data.R
@@ -61,7 +61,7 @@ test_that("validate_target_data works on multi-file time-series target data file
 
   res_ts <- validate_target_data(
     hub_path,
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     target_type = "time-series"
   )
   expect_s3_class(res_ts, c("target_validations", "hub_validations"))

--- a/tests/testthat/test-validate_target_file.R
+++ b/tests/testthat/test-validate_target_file.R
@@ -35,7 +35,7 @@ test_that("validate_target_file works with partitioned parquet target data file"
   # time-series CSV file
   res_ts <- validate_target_file(
     hub_path,
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet"
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet"
   )
   expect_s3_class(res_ts, "hub_validations")
   expect_named(

--- a/tests/testthat/test-validate_target_submission.R
+++ b/tests/testthat/test-validate_target_submission.R
@@ -71,7 +71,7 @@ test_that("validate_target_submission works on multi-file time-series target dat
 
   res_ts <- validate_target_submission(
     hub_path,
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     target_type = "time-series"
   )
   expect_s3_class(res_ts, c("target_validations", "hub_validations"))
@@ -135,7 +135,7 @@ test_that("validate_target_submission returns early as expected", {
   early_return_ts <- validate_target_submission(
     hub_path,
     # Use non-existent file to trigger early return file existence check
-    file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+    file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
     target_type = "time-series"
   )
   expect_s3_class(early_return_ts, c("target_validations", "hub_validations"))

--- a/vignettes/articles/validate-submission.Rmd
+++ b/vignettes/articles/validate-submission.Rmd
@@ -222,7 +222,7 @@ hub_path <- system.file("testhubs/v6/target_dir", package = "hubUtils")
 
 validate_target_submission(
   hub_path,
-  file_path = "time-series/target=wk%20flu%20hosp%20rate/part-0.parquet",
+  file_path = "time-series/target=flu_hosp_rate/part-0.parquet",
   target_type = "time-series"
 )
 ```


### PR DESCRIPTION
> [!IMPORTANT]
> **Blocked by:** hubverse-org/hubUtils#276
> Tests will fail until the hubUtils PR is merged and the updated package is available.

## Summary

- Updates tests, snapshots, examples, and vignettes to reflect renamed targets in hubUtils v5/v6 testhubs
- Target name changes:
  - `wk flu hosp rate` → `flu_hosp_rate`
  - `wk inc flu hosp` → `flu_hosp_inc`
  - `wk flu hosp rate category` → `flu_hosp_rate_cat`
- Only files referencing hubUtils v5/v6 testhubs were updated

## Test plan

- [x] `devtools::check()` passes (0 errors, 0 warnings)
- [x] All 1194 tests pass
- [x] pkgdown site builds successfully
- [x] CI will pass once hubUtils#276 is merged

Closes #310