### PR TITLE
Release v0.13.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 0.12.1.9000
+Version: 0.13.0
 Authors@R: c(
     person(
         given = "Anna", 
@@ -40,8 +40,8 @@ Imports:
     fs,
     gh,
     hubAdmin (>= 1.9.0),
-    hubData (>= 2.0.0.9002),
-    hubUtils (>= 1.1.0),
+    hubData (>= 2.1.0),
+    hubUtils (>= 1.2.0),
     jsonlite,
     jsonvalidate,
     lifecycle,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubValidations (development)
+# hubValidations 0.13.0
 
 ## Enhancements
 


### PR DESCRIPTION
> [!WARNING]
> Tests require hubData v2.1.0 to be released on r-universe to pass.

## Summary

- Bump version to 0.13.0
- Bump minimum hubData requirement to 2.1.0
- Bump minimum hubUtils requirement to 1.2.0

## Checklist

- [x] Version number updated in DESCRIPTION
- [x] NEWS.md updated with version heading
- [x] Authors verified
- [x] Remotes field checked
- [ ] CI passes against released dependency versions
- [ ] Review from hubverse dev team member