### PR TITLE
Post-release: bump to dev version 2.1.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 2.1.0
+Version: 2.1.0.9000
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubValidations (development version)
+
 # hubValidations 2.1.0
 
 * Added new `check_tbl_spl_mt_unique` check that validates individual sample `output_type_id`s do not span multiple model tasks. Different model tasks can have different sample configurations, so samples should be entirely independent across model tasks. The check runs upstream of other sample checks and returns an early error if violated (#333).


### PR DESCRIPTION
Bumps version to 2.1.0.9000 and adds development heading to NEWS.md following the 2.1.0 release.