### PR TITLE
Suppress gh pagination progress message in PR validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubValidations (development version)
 
+* Fixed `validate_pr()` and `validate_target_pr()` leaking a `gh` pagination progress message into their output by passing `.progress = FALSE` to the `gh::gh()` call (#347).
+
 # hubValidations 2.1.0
 
 * Added new `check_tbl_spl_mt_unique` check that validates individual sample `output_type_id`s do not span multiple model tasks. Different model tasks can have different sample configurations, so samples should be entirely independent across model tasks. The check runs upstream of other sample checks and returns an early error if violated (#333).

--- a/R/validate_pr.R
+++ b/R/validate_pr.R
@@ -182,7 +182,8 @@ validate_pr <- function(
         gh_repo = gh_repo,
         pr_number = pr_number,
         per_page = 100,
-        .limit = Inf
+        .limit = Inf,
+        .progress = FALSE
       )
       pr_df <- tibble::tibble(
         filename = purrr::map_chr(pr_files, ~ .x$filename),

--- a/R/validate_target_pr.R
+++ b/R/validate_target_pr.R
@@ -166,7 +166,8 @@ validate_target_pr <- function(
         gh_repo = gh_repo,
         pr_number = pr_number,
         per_page = 100,
-        .limit = Inf
+        .limit = Inf,
+        .progress = FALSE
       )
       pr_df <- tibble::tibble(
         filename = purrr::map_chr(pr_files, \(.x) .x$filename),


### PR DESCRIPTION
## Summary

`validate_pr()` and `validate_target_pr()` call `gh::gh(..., .limit = Inf)` to fetch PR files. As of gh 1.6.0 that paginated call emits a cli progress spinner (e.g. `⠙ 1 items, page 1 | 48ms`) as a captured `message` condition. This pollutes the functions' user-facing message output and shifts the position of real messages.

This caused the r-universe build failures for the 2.1.0 release ([build job](https://github.com/r-universe/hubverse-org/actions/runs/27491027943/job/81868232490)): the test `test-validate_target_pr.R:174,178` asserts on `msgs[1]`/`msgs[2]` by position, and the spinner became `msgs[1]`, pushing the real messages down one. The same leak was present in `validate_pr()` but went unnoticed because those tests are `skip_if_offline()`-guarded (see #348) and were skipped on r-universe.

Reproduces locally with gh 1.6.0, both authenticated and unauthenticated, so it is not a token or rate-limit problem.

## Change

Pass `.progress = FALSE` to both `gh::gh()` calls (the only two in the package). The argument has existed since gh 1.2.0, so no minimum gh version constraint is needed.

## Verification

Ran both PR validation test files with `NOT_CRAN=true` so the offline-guarded tests actually execute: **FAIL 0, WARN 0, SKIP 0, PASS 94**. Also confirmed directly that `validate_pr()` no longer leaks a progress-spinner message. air format and lintr both clean.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)