### PR TITLE
Add Plausible analytics to pkgdown site

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,7 +3,13 @@ template:
   bootstrap: 5
   package: hubStyle
   includes:
-    in_header: pkgdown/plausible.html
+    in_header: |
+      <!-- Privacy-friendly analytics by Plausible -->
+      <script async src="https://plausible.io/js/pa-WnwHUXKkRXbX_5qcMPxvY.js"></script>
+      <script>
+        window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+        plausible.init()
+      </script>
 
 reference:
 - title: "Utilities for submitting teams"

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,6 +2,8 @@ url: https://hubverse-org.github.io/hubValidations/
 template:
   bootstrap: 5
   package: hubStyle
+  includes:
+    in_header: pkgdown/plausible.html
 
 reference:
 - title: "Utilities for submitting teams"

--- a/pkgdown/plausible.html
+++ b/pkgdown/plausible.html
@@ -1,0 +1,6 @@
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-WnwHUXKkRXbX_5qcMPxvY.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>

--- a/pkgdown/plausible.html
+++ b/pkgdown/plausible.html
@@ -1,6 +1,0 @@
-<!-- Privacy-friendly analytics by Plausible -->
-<script async src="https://plausible.io/js/pa-WnwHUXKkRXbX_5qcMPxvY.js"></script>
-<script>
-  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
-  plausible.init()
-</script>


### PR DESCRIPTION
Adds Plausible analytics to the pkgdown documentation site by injecting the tracking script inline into <head> on every page via `template.includes.in_header` in `_pkgdown.yml`.