### PR TITLE
Release hubValidations 2.1.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 2.1.0.9000
+Version: 2.1.1
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubValidations (development version)
+# hubValidations 2.1.1
 
 * Fixed `validate_pr()` and `validate_target_pr()` leaking a `gh` pagination progress message into their output by passing `.progress = FALSE` to the `gh::gh()` call (#347).
 


### PR DESCRIPTION
Patch release bumping hubValidations to **2.1.1**.

## Changes

* Fixed `validate_pr()` and `validate_target_pr()` leaking a `gh` pagination progress message into their output by passing `.progress = FALSE` to the `gh::gh()` call (#347).