### PR TITLE
Bump to development version 2.1.1.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubValidations
 Title: Testing framework for hubverse hub validations
-Version: 2.1.1
+Version: 2.1.1.9000
 Authors@R: c(
     person(
         given = "Anna", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# hubValidations (development version)
+
 # hubValidations 2.1.1
 
 * Fixed `validate_pr()` and `validate_target_pr()` leaking a `gh` pagination progress message into their output by passing `.progress = FALSE` to the `gh::gh()` call (#347).


### PR DESCRIPTION
Post-release bump to development version `2.1.1.9000` following the 2.1.1 release.