### PR TITLE
Handle a compound_taskid_set of []

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # hubValidations (development version)
 
+* A `compound_taskid_set` of `[]`, which declares that every task ID is sampled jointly, no longer errors. `check_tbl_spl_compound_taskid_set()` failed with `` `config_comp_tids` must be logical, numeric, or character, not an empty list `` and `submission_tmpl()` with `invalid subscript type 'list'`. The check now passes when a submission's samples are drawn jointly across every task ID and, when they are finer, reports that the hub expects no compound task IDs and response dependence across all task IDs (#361).
+* `get_tbl_compound_taskid_set()` no longer drops modeling tasks whose detected compound task ID set is empty, which previously made a jointly sampled modeling task indistinguishable from one with no samples at all (#361).
+
 # hubValidations 2.1.1
 
 * Fixed `validate_pr()` and `validate_target_pr()` leaking a `gh` pagination progress message into their output by passing `.progress = FALSE` to the `gh::gh()` call (#347).

--- a/R/check_tbl_spl_compound_taskid_set.R
+++ b/R/check_tbl_spl_compound_taskid_set.R
@@ -24,12 +24,11 @@
 #' - `output_type_ids`: The output type ID of the sample that does not contain a
 #' single, unique value for each compound task ID.
 #'
-#' If the check failed because task IDs which is not allowed in the config, were identified
-#' as compound task ID (i.e. samples describe "finer" compound modeling tasks)
+#' If the check failed because task IDs the hub does not accept as compound task IDs
+#' were identified as such (i.e. samples describe "finer" compound modeling tasks)
 #' for a given model task, the `errors` object will be a list with the structure
 #' described above as well as the additional following elements:
-#' - `config_comp_tids`: the allowed `compound_taskid_set` defined in the modeling
-#' task config.
+#' - `config_comp_tids`: the `compound_taskid_set` the modeling task config expects.
 #' - `invalid_tbl_comp_tids`: the names of invalid compound task IDs.
 #'
 #' The name of each element is the index identifying the config modeling task the sample is associated with `mt_id`.

--- a/R/compound_taskid-utils.R
+++ b/R/compound_taskid-utils.R
@@ -96,7 +96,10 @@ get_tbl_compound_taskid_set <- function(
   )
 
   if (compact) {
-    tbl_compound_taskids <- purrr::compact(tbl_compound_taskids)
+    # Only modeling tasks without samples are dropped. An empty detected set is an
+    # answer rather than an absence, so it stays, which `purrr::compact()` would not
+    # do because it drops anything of length zero.
+    tbl_compound_taskids <- purrr::discard(tbl_compound_taskids, is.null)
   }
 
   tbl_compound_taskids
@@ -197,10 +200,17 @@ get_mt_compound_taskid_set <- function(
   if (!all(tbl_comp_tids %in% config_comp_tids)) {
     invalid_tbl_comp_tids <- setdiff(tbl_comp_tids, config_comp_tids)
 
+    expected_msg <- if (length(config_comp_tids) == 0L) {
+      "The hub expects no compound task IDs and response dependence across all
+      task IDs."
+    } else {
+      "Compound task IDs should be one of {.val {config_comp_tids}}."
+    }
+
     error_vec <- c(
-      "x" = "Finer {.var compound_taskid_set} than allowed detected.",
-      "!" = "{.val {invalid_tbl_comp_tids}} identified as compound task ID{?s} in file but not allowed in config.",
-      "i" = "Compound task IDs should be one of {.val {config_comp_tids}}."
+      "x" = "Detected a finer {.var compound_taskid_set} than the hub accepts.",
+      "!" = "{.val {invalid_tbl_comp_tids}} identified as compound task ID{?s} in file but not accepted by the hub.",
+      "i" = expected_msg
     )
 
     if (error) {

--- a/R/utils-samples.R
+++ b/R/utils-samples.R
@@ -213,7 +213,9 @@ get_model_task_compound_taskid_set <- function(x, config_tasks, round_id) {
   if (is.null(output_type_id_params$compound_taskid_set)) {
     return(hubUtils::get_round_task_id_names(config_tasks, round_id))
   }
-  output_type_id_params$compound_taskid_set
+  # A `compound_taskid_set` of `[]` reads back as an empty list rather than an empty
+  # character vector, which no longer works as a column index.
+  as.character(output_type_id_params$compound_taskid_set)
 }
 
 ## --- v3 sample check utils ---------------------------------------------------
@@ -403,7 +405,13 @@ add_mt_sample_idx <- function(
     output_type = "sample",
     output_type_id = seq_len(nrow(spl_unique)) + start_idx
   )
-  spl <- dplyr::left_join(spl_unique, spl, by = comp_tids)
+  spl <- if (length(comp_tids) == 0L) {
+    # No compound task IDs means the whole modeling task is one sample, so every row
+    # belongs to the single sample ID.
+    dplyr::cross_join(spl_unique, spl)
+  } else {
+    dplyr::left_join(spl_unique, spl, by = comp_tids)
+  }
 
   if (!is.null(type) && type == "character") {
     spl[[config_tid]] <- sprintf("s%s", spl[[config_tid]])

--- a/man/check_tbl_spl_compound_taskid_set.Rd
+++ b/man/check_tbl_spl_compound_taskid_set.Rd
@@ -65,13 +65,12 @@ for a given model task, the \code{errors} object will be a list with one element
 single, unique value for each compound task ID.
 }
 
-If the check failed because task IDs which is not allowed in the config, were identified
-as compound task ID (i.e. samples describe "finer" compound modeling tasks)
+If the check failed because task IDs the hub does not accept as compound task IDs
+were identified as such (i.e. samples describe "finer" compound modeling tasks)
 for a given model task, the \code{errors} object will be a list with the structure
 described above as well as the additional following elements:
 \itemize{
-\item \code{config_comp_tids}: the allowed \code{compound_taskid_set} defined in the modeling
-task config.
+\item \code{config_comp_tids}: the \code{compound_taskid_set} the modeling task config expects.
 \item \code{invalid_tbl_comp_tids}: the names of invalid compound task IDs.
 }
 

--- a/tests/testthat/_snaps/check_tbl_spl_compound_taskid_set.md
+++ b/tests/testthat/_snaps/check_tbl_spl_compound_taskid_set.md
@@ -23,7 +23,7 @@
     Output
       <error/check_error>
       Error:
-      ! All samples in a model task do not conform to single, unique compound task ID set that matches or is coarser than the configured `compound_taskid_set`.  mt 2: Finer `compound_taskid_set` than allowed detected. "horizon" identified as compound task ID in file but not allowed in config. Compound task IDs should be one of "reference_date" and "location".
+      ! All samples in a model task do not conform to single, unique compound task ID set that matches or is coarser than the configured `compound_taskid_set`.  mt 2: Detected a finer `compound_taskid_set` than the hub accepts. "horizon" identified as compound task ID in file but not accepted by the hub. Compound task IDs should be one of "reference_date" and "location".
 
 ---
 
@@ -282,7 +282,7 @@
     Output
       <error/check_error>
       Error:
-      ! All samples in a model task do not conform to single, unique compound task ID set that matches or is coarser than the configured `compound_taskid_set`.  mt 2: Finer `compound_taskid_set` than allowed detected. "variant" identified as compound task ID in file but not allowed in config. Compound task IDs should be one of "reference_date", "horizon", "location", and "target_end_date".
+      ! All samples in a model task do not conform to single, unique compound task ID set that matches or is coarser than the configured `compound_taskid_set`.  mt 2: Detected a finer `compound_taskid_set` than the hub accepts. "variant" identified as compound task ID in file but not accepted by the hub. Compound task IDs should be one of "reference_date", "horizon", "location", and "target_end_date".
 
 ---
 
@@ -317,4 +317,22 @@
       <message/check_success>
       Message:
       All samples in a model task conform to single, unique compound task ID set that matches the configured `compound_taskid_set`.
+
+# check_tbl_spl_compound_taskid_set works with an empty compound_taskid_set
+
+    Code
+      check_tbl_spl_compound_taskid_set(joint, round_id, file_path, hub_path)
+    Output
+      <message/check_success>
+      Message:
+      All samples in a model task conform to single, unique compound task ID set that matches the configured `compound_taskid_set`.
+
+---
+
+    Code
+      check_tbl_spl_compound_taskid_set(tbl, round_id, file_path, hub_path)
+    Output
+      <error/check_error>
+      Error:
+      ! All samples in a model task do not conform to single, unique compound task ID set that matches or is coarser than the configured `compound_taskid_set`.  mt 2: Detected a finer `compound_taskid_set` than the hub accepts. "location" identified as compound task ID in file but not accepted by the hub. The hub expects no compound task IDs and response dependence across all task IDs.
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -71,3 +71,20 @@ create_spl_file <- function(
 create_file_path <- function(round_id, model_id = "flu-base", ext = "parquet") {
   fs::path(model_id, paste0(round_id, "-", model_id), ext = ext)
 }
+
+# A hub whose config declares a `compound_taskid_set` of `[]`, i.e. that nothing is a
+# compound task ID and every task ID is sampled jointly.
+empty_cts_hub <- function(env = parent.frame()) {
+  hub_path <- withr::local_tempdir(.local_envir = env)
+  fs::dir_copy(
+    system.file("testhubs/samples", package = "hubValidations"),
+    hub_path,
+    overwrite = TRUE
+  )
+  fs::file_copy(
+    test_path("testdata/configs/tasks-samples-empty-cts.json"),
+    fs::path(hub_path, "hub-config", "tasks.json"),
+    overwrite = TRUE
+  )
+  hub_path
+}

--- a/tests/testthat/test-check_tbl_spl_compound_taskid_set.R
+++ b/tests/testthat/test-check_tbl_spl_compound_taskid_set.R
@@ -299,3 +299,63 @@ test_that("Ignoring derived_task_ids in check_tbl_spl_compound_taskid_set works"
     )
   )
 })
+
+test_that("check_tbl_spl_compound_taskid_set works with an empty compound_taskid_set", {
+  hub_path <- empty_cts_hub()
+  file_path <- "flu-base/2022-10-22-flu-base.csv"
+  round_id <- "2022-10-22"
+  tbl <- read_model_out_file(file_path, hub_path, coerce_types = "chr")
+  tbl <- tbl[tbl$output_type == "sample", ]
+  task_ids <- setdiff(names(tbl), c(hubUtils::std_colnames, "value"))
+
+  # Give every sample one row per task ID value combination, so no task ID holds a
+  # single value within a sample and the detected set is empty, as configured.
+  joint <- tbl |>
+    dplyr::group_by(dplyr::pick(dplyr::all_of(task_ids))) |>
+    dplyr::mutate(output_type_id = as.character(dplyr::row_number())) |>
+    dplyr::ungroup()
+
+  expect_snapshot(
+    check_tbl_spl_compound_taskid_set(joint, round_id, file_path, hub_path)
+  )
+  config_tasks <- read_config(hub_path, "tasks")
+  expect_equal(
+    get_tbl_compound_taskid_set(joint, config_tasks, round_id, compact = FALSE),
+    list(`1` = NULL, `2` = character(0))
+  )
+  # Compacting drops the modeling task without samples but keeps the empty detected
+  # set, which is an answer rather than an absence.
+  expect_equal(
+    get_tbl_compound_taskid_set(joint, config_tasks, round_id),
+    list(`2` = character(0))
+  )
+
+  # The file as submitted keeps each sample to one location, which is a finer set
+  # than a hub expecting none.
+  expect_snapshot(
+    check_tbl_spl_compound_taskid_set(tbl, round_id, file_path, hub_path)
+  )
+})
+
+test_that("validation passes end to end with an empty compound_taskid_set", {
+  hub_path <- empty_cts_hub()
+  file_path <- "flu-base/2022-10-22-flu-base.csv"
+  tbl <- read_model_out_file(file_path, hub_path, coerce_types = "chr")
+  spl <- tbl[tbl$output_type == "sample", ]
+  task_ids <- setdiff(names(spl), c(hubUtils::std_colnames, "value"))
+
+  joint <- spl |>
+    dplyr::group_by(dplyr::pick(dplyr::all_of(task_ids))) |>
+    dplyr::mutate(output_type_id = as.character(dplyr::row_number())) |>
+    dplyr::ungroup()
+  utils::write.csv(
+    rbind(tbl[tbl$output_type != "sample", ], joint),
+    fs::path(hub_path, "model-output", file_path),
+    row.names = FALSE
+  )
+
+  # The empty set has to reach the other sample checks unchanged for them to read it
+  # as "every task ID is sampled jointly" rather than as no configuration at all.
+  checks <- validate_model_data(hub_path, file_path)
+  expect_true(all(purrr::map_lgl(checks, \(.x) !is_any_error(.x))))
+})

--- a/tests/testthat/test-check_tbl_spl_compound_taskid_set.R
+++ b/tests/testthat/test-check_tbl_spl_compound_taskid_set.R
@@ -338,6 +338,11 @@ test_that("check_tbl_spl_compound_taskid_set works with an empty compound_taskid
 })
 
 test_that("validation passes end to end with an empty compound_taskid_set", {
+  # The other sample checks all read the compound task ID set, and an empty one is easy
+  # to lose on the way to them: dropped when compacting, or arriving as `NULL`. Either
+  # way they would see nothing configured and read it as an absent set, which asks for
+  # the opposite of what an empty one does. So this calls `validate_model_data()` rather
+  # than the check on its own, to pin that the empty set reaches them intact.
   hub_path <- empty_cts_hub()
   file_path <- "flu-base/2022-10-22-flu-base.csv"
   tbl <- read_model_out_file(file_path, hub_path, coerce_types = "chr")
@@ -354,8 +359,6 @@ test_that("validation passes end to end with an empty compound_taskid_set", {
     row.names = FALSE
   )
 
-  # The empty set has to reach the other sample checks unchanged for them to read it
-  # as "every task ID is sampled jointly" rather than as no configuration at all.
   checks <- validate_model_data(hub_path, file_path)
   expect_true(all(purrr::map_lgl(checks, \(.x) !is_any_error(.x))))
 })

--- a/tests/testthat/test-submission_tmpl.R
+++ b/tests/testthat/test-submission_tmpl.R
@@ -462,3 +462,18 @@ test_that("submission_tmpl works with SubTreeFileSystems", {
     regexp = "is not a JSON file"
   )
 })
+
+test_that("submission_tmpl handles an empty compound_taskid_set", {
+  hub_path <- empty_cts_hub()
+
+  # No compound task IDs means the modeling task is a single compound modeling task,
+  # so the template carries one sample covering every task ID value combination.
+  expect_no_warning(
+    tmpl <- submission_tmpl(hub_path, round_id = "2022-10-22")
+  )
+  spl <- tmpl[tmpl$output_type == "sample", ]
+  task_ids <- setdiff(names(spl), c(hubUtils::std_colnames, "value"))
+
+  expect_equal(dplyr::n_distinct(spl$output_type_id), 1L)
+  expect_equal(nrow(spl), nrow(unique(spl[, task_ids])))
+})

--- a/tests/testthat/testdata/configs/tasks-samples-empty-cts.json
+++ b/tests/testthat/testdata/configs/tasks-samples-empty-cts.json
@@ -1,0 +1,307 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "reference_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22",
+                                "2022-10-29",
+                                "2022-11-05",
+                                "2022-11-12",
+                                "2022-11-19",
+                                "2022-11-26",
+                                "2022-12-03",
+                                "2022-12-10",
+                                "2022-12-17",
+                                "2022-12-24",
+                                "2022-12-31",
+                                "2023-01-07",
+                                "2023-01-14",
+                                "2023-01-21",
+                                "2023-01-28",
+                                "2023-02-04",
+                                "2023-02-11",
+                                "2023-02-18",
+                                "2023-02-25",
+                                "2023-03-04",
+                                "2023-03-11",
+                                "2023-03-18",
+                                "2023-03-25",
+                                "2023-04-01",
+                                "2023-04-08",
+                                "2023-04-15",
+                                "2023-04-22",
+                                "2023-04-29",
+                                "2023-05-06"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": [
+                                "wk flu hosp rate category"
+                            ]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [
+                                0,
+                                1,
+                                2,
+                                3
+                            ]
+                        },
+                        "location": {
+                            "required": [
+                                "US",
+                                "01"
+                            ],
+                            "optional": [
+                                "02",
+                                "04",
+                                "05"
+                            ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22",
+                                "2022-10-29",
+                                "2022-11-05",
+                                "2022-11-12",
+                                "2022-11-19",
+                                "2022-11-26",
+                                "2022-12-03",
+                                "2022-12-10",
+                                "2022-12-17",
+                                "2022-12-24",
+                                "2022-12-31",
+                                "2023-01-07",
+                                "2023-01-14",
+                                "2023-01-21",
+                                "2023-01-28",
+                                "2023-02-04",
+                                "2023-02-11",
+                                "2023-02-18",
+                                "2023-02-25",
+                                "2023-03-04",
+                                "2023-03-11",
+                                "2023-03-18",
+                                "2023-03-25",
+                                "2023-04-01",
+                                "2023-04-08",
+                                "2023-04-15",
+                                "2023-04-22",
+                                "2023-04-29",
+                                "2023-05-06",
+                                "2023-05-13",
+                                "2023-05-20",
+                                "2023-05-27"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "pmf": {
+                            "output_type_id": {
+                                "required": [
+                                    "low",
+                                    "moderate",
+                                    "high",
+                                    "very high"
+                                ],
+                                "optional": null
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0,
+                                "maximum": 1
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk flu hosp rate category",
+                            "target_name": "week ahead weekly influenza hospitalization rate category",
+                            "target_units": "rate per 100,000 population",
+                            "target_keys": {
+                                "target": [
+                                    "wk flu hosp rate category"
+                                ]
+                            },
+                            "target_type": "ordinal",
+                            "description": "This target represents a categorical severity level for rate of new hospitalizations per week for the week ending [horizon] weeks after the reference_date, on target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                },
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22",
+                                "2022-10-29",
+                                "2022-11-05",
+                                "2022-11-12",
+                                "2022-11-19",
+                                "2022-11-26",
+                                "2022-12-03",
+                                "2022-12-10",
+                                "2022-12-17",
+                                "2022-12-24",
+                                "2022-12-31",
+                                "2023-01-07",
+                                "2023-01-14",
+                                "2023-01-21",
+                                "2023-01-28",
+                                "2023-02-04",
+                                "2023-02-11",
+                                "2023-02-18",
+                                "2023-02-25",
+                                "2023-03-04",
+                                "2023-03-11",
+                                "2023-03-18",
+                                "2023-03-25",
+                                "2023-04-01",
+                                "2023-04-08",
+                                "2023-04-15",
+                                "2023-04-22",
+                                "2023-04-29",
+                                "2023-05-06"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": [
+                                "wk inc flu hosp"
+                            ]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [
+                                0,
+                                1,
+                                2,
+                                3
+                            ]
+                        },
+                        "location": {
+                            "required": [
+                                "US",
+                                "01"
+                            ],
+                            "optional": [
+                                "02",
+                                "04",
+                                "05"
+                            ]
+                        },
+                        "target_end_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22",
+                                "2022-10-29",
+                                "2022-11-05",
+                                "2022-11-12",
+                                "2022-11-19",
+                                "2022-11-26",
+                                "2022-12-03",
+                                "2022-12-10",
+                                "2022-12-17",
+                                "2022-12-24",
+                                "2022-12-31",
+                                "2023-01-07",
+                                "2023-01-14",
+                                "2023-01-21",
+                                "2023-01-28",
+                                "2023-02-04",
+                                "2023-02-11",
+                                "2023-02-18",
+                                "2023-02-25",
+                                "2023-03-04",
+                                "2023-03-11",
+                                "2023-03-18",
+                                "2023-03-25",
+                                "2023-04-01",
+                                "2023-04-08",
+                                "2023-04-15",
+                                "2023-04-22",
+                                "2023-04-29",
+                                "2023-05-06",
+                                "2023-05-13",
+                                "2023-05-20",
+                                "2023-05-27"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "mean": {
+                            "output_type_id": {
+                                "required": null,
+                                "optional": [
+                                    "NA"
+                                ]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        },
+                        "median": {
+                            "output_type_id": {
+                                "required": null,
+                                "optional": [
+                                    "NA"
+                                ]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        },
+                        "sample": {
+                            "output_type_id_params": {
+                                "is_required": true,
+                                "type": "integer",
+                                "min_samples_per_task": 100,
+                                "max_samples_per_task": 100,
+                                "compound_taskid_set": []
+                            },
+                            "value": {
+                                "type": "integer",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk inc flu hosp",
+                            "target_name": "incident influenza hospitalizations",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": [
+                                    "wk inc flu hosp"
+                                ]
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of new hospitalizations in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {
+                "relative_to": "reference_date",
+                "start": -6,
+                "end": -3
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Resolves #361.

A `compound_taskid_set` of `[]` declares that every task ID is sampled jointly. It
passes config validation, but `read_config()` returns it as an empty list rather than
an empty character vector, and an empty list cannot index a column. So
`check_tbl_spl_compound_taskid_set()` stopped with an exec error, and
`submission_tmpl()` failed with `invalid subscript type 'list'`.

## The fix

The issue suggested guarding the assignment that breaks first. The fix in this PR
instead normalises the value where the config is read, so every consumer gets a
character vector. That matters because the empty list reaches more than one place, as
the rest of this description shows.

Three further problems only became visible once an empty set was a value that reached
those consumers:

- `get_tbl_compound_taskid_set()` dropped it when compacting, because
  `purrr::compact()` removes anything of length zero. A modeling task whose samples
  are correctly jointly sampled was indistinguishable in the output from one with no
  samples at all, which contradicted the function's own documentation. It now drops
  only `NULL`.
- Building sample indices joined on no columns at all, which dplyr deprecated in
  favour of `cross_join()`. This is why `submission_tmpl()` warned once the first fix
  was in.
- The "finer than the hub accepts" message ended in "should be one of ." when there
  was nothing to list.

## Message wording

That last message now describes what the hub accepts rather than what its config
allows, since the config is a statement of what the hub wants in submissions rather
than a list of permissions. **This applies to every hub, not only those declaring
`[]`**, and two existing snapshots change accordingly:

> Detected a finer `compound_taskid_set` than the hub accepts. "horizon" identified as
> compound task ID in file but not accepted by the hub. Compound task IDs should be one
> of "reference_date" and "location".

For an empty set the last sentence instead reads "The hub expects no compound task IDs
and response dependence across all task IDs", using the term
[the sample docs use](https://docs.hubverse.io/en/latest/user-guide/sample-output-type.html).

## A docs gap this turns up

The sample docs state the general rule — task IDs not in the `compound_taskid_set` are
sampled jointly — from which `[]` follows unambiguously: none are in the set, so every
task ID is sampled jointly. The empty case is never named or exemplified there, and an
absent `compound_taskid_set` means the opposite, so the two are easy to conflate. Raised
as hubverse-org/hubDocs#507.

## Testing

- A jointly sampled submission passes against a `[]` config and is reported as
  *matching* the configured set; the file as shipped, which keeps each sample to one
  location, fails as finer.
- `validate_model_data()` end to end on a `[]` hub, asserting no errors. The empty set
  has to reach `spl_compound_tid`, `spl_non_compound_tid` and `spl_n` unchanged for
  them to read it as "every task ID is sampled jointly", and nothing else pinned that.
- `submission_tmpl()` returns one sample covering every task ID value combination, with
  no warning.

Adds config fixture `testdata/configs/tasks-samples-empty-cts.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

